### PR TITLE
Add TravisCI /  PyPI release integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,12 @@ install:
 
 script:
   - tox
+
+deploy:
+  provider: pypi
+  user: "hawkrives"
+  password:
+    secure: kxjTndHBVztrPi1k74zsL2cjbFrBXe5af0HDn/t4w6CUj0yCf0VPwzR0KnOU6CrvRpMxid7MINsgdh3MsOsgnLiLiQ4TSRqEfB9lsmCopDXArNiC5jq0QmZ1P2KHKguJpkWx8TnwjiJycm1UFJU3l4YRfj5Zo4LvpI/64EUoNhICbf2gAQav8Sb2a9/Ov5hpySBYhmwr/tkODOfZS5+00SAs/OP7bU0xQFhUUwnEY4uAiaTIo+tIOIXx/nwj7XundCEwFXiFDYSEKbk+maHWgUIqbZivL94RigVwTds0KJmpurU1Nc670ggGwT96WcCtNZoMTxB47fXoNqzhTAgp2O2C4lsv1xNIrwSdHzyP20wsDQn3zdMz4aJEfSZMwhvN/GJyQFTKbeD++ysRsfUuI5uQho7BOsGMLDfnDOpncNNXI2zKnea9OStsj/u/aJGNmWFcGa70/CHBeSI9Zmv6Og3KY6fGM28bqQUvO6iFDho98xOTHk+vTIcGyut5DDMuKvQh3ISPYZkz7lSqHqDayXr/RxombkpEPszqlUkn2OO38PLujYJzL8nLUN1g/2m2M4y9h6pXV27sU6hDo0E9WTtRhAA04JqpsJ2S8smw2C+yo446klaMNxUkYbxm4j9PI7pYpLWsqlOMbnCz79PSGuzB17ezk6nr8T22TR0Ci2w=
+  on:
+    # only deploy tags
+    tags: true


### PR DESCRIPTION
Now, when a new tag is pushed and built by Travis, it will go ahead and publish that as a release on PyPI.

I don't think you can make new tags from Github yet, though (releases don't count), so we can't quite release entirely from the website yet.

However, this _will_ allow @rye (or anyone with commit access) to deploy new releases O_o