### PR TITLE
Add tests for common/chdir, common/dirsize, and about half of the funcs in tabulate

### DIFF
--- a/cs251tk/common/test_chdir.py
+++ b/cs251tk/common/test_chdir.py
@@ -1,0 +1,13 @@
+from pyfakefs import fake_filesystem
+from .chdir import chdir
+
+
+def test_chdir(fs):
+    os_module = fake_filesystem.FakeOsModule(fs)
+
+    fs.CreateDirectory('./folder')
+
+    assert os_module.getcwd() == '/'
+    with chdir('./folder'):
+        assert os_module.getcwd() == '/folder'
+    assert os_module.getcwd() == '/'

--- a/cs251tk/common/test_dirsize.py
+++ b/cs251tk/common/test_dirsize.py
@@ -1,0 +1,15 @@
+from pyfakefs import fake_filesystem
+from .dirsize import dirsize
+
+
+def test_chdir(fs):
+    os_module = fake_filesystem.FakeOsModule(fs)
+
+    fs.CreateDirectory('/folder')
+    fs.CreateFile('/folder/file1', contents='0123456789')
+    fs.CreateFile('/folder/file2', contents='0123456789')
+    fs.CreateFile('/folder/file3', contents='0123456789')
+    fs.CreateFile('/folder/file4', contents='0123456789')
+    fs.CreateFile('/folder/file5', contents='0123456789')
+
+    print(dirsize('/folder'))

--- a/cs251tk/toolkit/test_tabulate.py
+++ b/cs251tk/toolkit/test_tabulate.py
@@ -70,3 +70,12 @@ def test_columnize():
     }
 
     assert columnize(student2, 'rives', 2, 1) == "\033[1mrives\033[0m  | 1 2 | 1"
+
+    student3 = {
+        'username': 'rives',
+        'error': 'an error occurred',
+        'homeworks': [],
+        'labs': [],
+    }
+
+    assert columnize(student3, 'rives', 2, 1) == "{username}  | {error}".format(**student3)

--- a/cs251tk/toolkit/test_tabulate.py
+++ b/cs251tk/toolkit/test_tabulate.py
@@ -56,3 +56,17 @@ def test_columnize():
     assert columnize(student, 'long_username', 2, 1) == "rives          | 1 2 | 1"
     assert columnize(student, 'rives', 5, 1) == "rives  | 1 2 - - - | 1"
     assert columnize(student, 'rives', 2, 5) == "rives  | 1 2 | 1 - - - -"
+
+    student2 = {
+        'username': 'rives',
+        'unmerged_branches': True,
+        'homeworks': [
+            {'number': 1, 'status': 'success'},
+            {'number': 2, 'status': 'success'},
+        ],
+        'labs': [
+            {'number': 1, 'status': 'success'},
+        ]
+    }
+
+    assert columnize(student2, 'rives', 2, 1) == "\033[1mrives\033[0m  | 1 2 | 1"


### PR DESCRIPTION
Goin' up!

Next up, the single buggiest piece of code: `tabulate.py`'s `get_nums` function.

After that, `tabulate` itself.