### PR TITLE
Clean up run()

### DIFF
--- a/cs251tk/common/find_unmerged_branches_in_cwd.py
+++ b/cs251tk/common/find_unmerged_branches_in_cwd.py
@@ -5,7 +5,6 @@ from .run import run
 def find_unmerged_branches_in_cwd():
     """Check for unmerged branches in the current repository"""
     _, unmerged_branches = run(['git', 'branch', '-a', '--no-merged', 'master'])
-    unmerged_branches = [s.strip()
-                         for s in unmerged_branches.split('\n')
-                         if s.strip()]
-    return unmerged_branches
+    return [s.strip()
+            for s in unmerged_branches.split('\n')
+            if s.strip()]

--- a/cs251tk/common/run.py
+++ b/cs251tk/common/run.py
@@ -1,7 +1,6 @@
-import shlex
 import copy
 import os
-from subprocess import STDOUT, check_output, CalledProcessError, TimeoutExpired
+from subprocess import STDOUT, run as _run, CalledProcessError, TimeoutExpired
 
 
 # This env stuff is to catch glibc errors, because
@@ -11,20 +10,16 @@ ENV = copy.copy(os.environ)
 ENV["LIBC_FATAL_STDERR_"] = "1"
 
 
-def run(cmd, *args, input=None, timeout=None, **kwargs):
-    if isinstance(cmd, str):
-        cmd = shlex.split(str)
-
+def run(cmd, input_data=None, timeout=None):
+    status = 'success'
     try:
-        status = 'success'
-        result = check_output(
+        result = _run(
             cmd,
-            *args,
             stderr=STDOUT,
             timeout=timeout,
-            input=input,
+            input=input_data,
             env=ENV,
-            **kwargs)
+            check=True)
 
     except CalledProcessError as err:
         status = 'called process error'
@@ -40,7 +35,7 @@ def run(cmd, *args, input=None, timeout=None, **kwargs):
 
     except ProcessLookupError as err:
         try:
-            status, result = run(*args, status=status, **kwargs)
+            status, result = run(cmd, input_data=input_data, timeout=timeout)
         except:
             status = 'process lookup error'
             result = str(err)

--- a/cs251tk/student/checkout.py
+++ b/cs251tk/student/checkout.py
@@ -5,8 +5,7 @@ from cs251tk.common import run
 def checkout_date(student, date=None):
     if date:
         with chdir(student):
-            rev_list = ['git', 'rev-list', '-n', '1', '--before="{} 18:00"'.format(date), 'master']
-            _, rev = run(rev_list)
+            _, rev = run(['git', 'rev-list', '-n', '1', '--before="{} 18:00"'.format(date), 'master'])
             run(['git', 'checkout', rev, '--force', '--quiet'])
 
 

--- a/cs251tk/student/markdownify.py
+++ b/cs251tk/student/markdownify.py
@@ -45,7 +45,7 @@ def kinda_pipe_commands(cmd_string):
     input_for_cmd = None
     for cmd in cmds[:-1]:
         cmd = process_chunk(cmd)
-        _, input_for_cmd = run(cmd, input=input_for_cmd)
+        _, input_for_cmd = run(cmd, input_data=input_for_cmd)
         input_for_cmd = input_for_cmd.encode('utf-8')
 
     final_cmd = process_chunk(cmds[-1])
@@ -106,7 +106,7 @@ def process_file(filename, steps, options, spec, cwd, supporting_dir):
         command = step.replace('$@', './' + filename)
         command = command.replace('$SUPPORT', supporting_dir)
         cmd, input_for_cmd = kinda_pipe_commands(command)
-        status, compilation = run(cmd, input=input_for_cmd)
+        status, compilation = run(cmd, input_data=input_for_cmd)
 
         results['compilation'].append({
             'command': command,
@@ -135,7 +135,7 @@ def process_file(filename, steps, options, spec, cwd, supporting_dir):
 
         if exists(path_join(cwd, filename)):
             status, full_result = run(test_cmd,
-                                      input=input_for_test,
+                                      input_data=input_for_test,
                                       timeout=options['timeout'])
 
             result = unicode_truncate(full_result, options['truncate_output'])

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         'PyYAML == 3.*',
         'requests == 2.*',
         'termcolor == 1.*',
-        'natsort == 5.0.*'
+        'natsort == 5.0.*',
     ],
     tests_require=['tox'],
     packages=find_packages(exclude=['tests', 'docs']),


### PR DESCRIPTION
Two main things:

1. I removed the support for calling run() with multiple args as the command to run: `run('git', 'log')` instead of `run(['git', 'log'])`. Nothing used that syntax anymore.
2. I renamed the `input` argument to `input_data`

It's got a much cleaner function signature now.