### PR TITLE
use pypi pyfakefs package

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,5 +7,5 @@ envlist = py35,py36
 deps = pytest
        pytest-pep8
        pytest-cov
-       https://github.com/jmcgeheeiv/pyfakefs/tarball/1029ffb1f0f81856677d1e7141130254abf54c25#egg=pyfakefs-3.1beta
+       pyfakefs
 commands = py.test


### PR DESCRIPTION
We had to use the git repo directly for a bit, because the pytest plugin wasn't released yet.

Now it is!