### PR TITLE
Finish off tests for tabulate.py

### DIFF
--- a/cs251tk/toolkit/tabulate.py
+++ b/cs251tk/toolkit/tabulate.py
@@ -100,7 +100,7 @@ def get_nums(students):
     return max_hwk_num, max_lab_num
 
 
-def tabulate(students, sort_by, partials):
+def tabulate(students, sort_by='name', partials=False):
     """Actually build the table"""
     global HIGHLIGHT_PARTIALS
     HIGHLIGHT_PARTIALS = partials

--- a/cs251tk/toolkit/tabulate.py
+++ b/cs251tk/toolkit/tabulate.py
@@ -24,6 +24,7 @@ def sort_by_username(user):
 
 
 def asciiify(table):
+    """Take a flashy unicode table and render it with ASCII-only chars"""
     table = table.replace('│', '|')
     table = table.replace('─', '-')
     table = table.replace('┼', '-')

--- a/cs251tk/toolkit/tabulate.py
+++ b/cs251tk/toolkit/tabulate.py
@@ -15,7 +15,7 @@ ANSI_ESCAPE = re.compile(r'\x1b[^m]*m')
 
 def sort_by_hw_count(user):
     """Sort students by the number of completed homeworks"""
-    return sum([1 if hw['status'] == 'complete' else 0 for hw in user['homework']])
+    return sum([1 if hw['status'] == 'complete' else 0 for hw in user['homeworks']])
 
 
 def sort_by_username(user):

--- a/cs251tk/toolkit/tabulate.py
+++ b/cs251tk/toolkit/tabulate.py
@@ -15,6 +15,16 @@ HIGHLIGHT_PARTIALS = False
 ANSI_ESCAPE = re.compile(r'\x1b[^m]*m')
 
 
+def sort_by_hw_count(user):
+    """Sort students by the number of completed homeworks"""
+    return sum([1 if hw['status'] == 'complete' else 0 for hw in user['homework']])
+
+
+def sort_by_username(user):
+    """Sort students by their username"""
+    return user['username']
+
+
 def asciiify(table):
     table = table.replace('│', '|')
     table = table.replace('─', '-')
@@ -132,12 +142,10 @@ def tabulate(students, sort_by, partials):
 
     # build the table body
     if sort_by == 'count':
-        def sorter(user):
-            return sum([1 if hw['status'] == 'complete' else 0 for hw in user['homework']])
+        sorter = sort_by_hw_count
         should_reverse = True
     else:
-        def sorter(user):
-            return user['username']
+        sorter = sort_by_username
         should_reverse = False
 
     lines = [columnize(student, longest_user, max_hwk_num, max_lab_num)

--- a/cs251tk/toolkit/tabulate.py
+++ b/cs251tk/toolkit/tabulate.py
@@ -73,8 +73,8 @@ def columnize(student, longest_user, max_hwk_num, max_lab_num):
     if student.get('unmerged_branches', False):
         name = colored(name, attrs={'bold': True})
 
-    homework_row = concat(student['homeworks'], max_hwk_num)
-    lab_row = concat(student['labs'], max_lab_num)
+    homework_row = concat(student.get('homeworks', []), max_hwk_num)
+    lab_row = concat(student.get('labs', []), max_lab_num)
 
     if 'error' in student:
         return '{name}  {sep} {err}'.format(

--- a/cs251tk/toolkit/tabulate.py
+++ b/cs251tk/toolkit/tabulate.py
@@ -15,7 +15,7 @@ ANSI_ESCAPE = re.compile(r'\x1b[^m]*m')
 
 def sort_by_hw_count(user):
     """Sort students by the number of completed homeworks"""
-    return sum([1 if hw['status'] == 'complete' else 0 for hw in user['homeworks']])
+    return sum([1 if hw['status'] == 'success' else 0 for hw in user['homeworks']])
 
 
 def sort_by_username(user):

--- a/cs251tk/toolkit/tabulate.py
+++ b/cs251tk/toolkit/tabulate.py
@@ -2,8 +2,6 @@
 import re
 from sys import stdout
 from termcolor import colored
-from logging import warning
-from cs251tk.common import flatten
 
 UNICODE = stdout.encoding == 'UTF-8' and stdout.isatty()
 # unicode = False
@@ -91,22 +89,12 @@ def columnize(student, longest_user, max_hwk_num, max_lab_num):
 
 
 def get_nums(students):
-    homework_nums = flatten([[hw['number'] for hw in s.get('homeworks', [])] for s in students])
-    lab_nums = flatten([[lab['number'] for lab in s.get('labs', [])] for s in students])
+    """Given a list of students, return the higest hw and lab number among them"""
+    homework_nums = [hw['number'] for s in students for hw in s.get('homeworks', [])]
+    lab_nums = [lab['number'] for s in students for lab in s.get('labs', [])]
 
-    if not homework_nums:
-        warning('no homework assignments were given to tabulate')
-        warning('from these students:')
-        warning(students)
-        return 0, 0
-    if not lab_nums:
-        warning('no labs were given to tabulate')
-        warning('from these students:')
-        warning(students)
-        return 0, 0
-
-    max_hwk_num = max(homework_nums)
-    max_lab_num = max(lab_nums)
+    max_hwk_num = max(homework_nums, default=0)
+    max_lab_num = max(lab_nums, default=0)
 
     return max_hwk_num, max_lab_num
 

--- a/cs251tk/toolkit/test_tabulate.py
+++ b/cs251tk/toolkit/test_tabulate.py
@@ -80,6 +80,13 @@ def test_columnize():
 
     assert columnize(student3, 'rives', 2, 1) == "{username}  | {error}".format(**student3)
 
+    student4 = {
+        'username': 'rives',
+        'error': 'an error occurred',
+    }
+
+    assert columnize(student4, 'rives', 0, 0) == "{username}  | {error}".format(**student4)
+
 
 def test_get_nums():
     assert get_nums([

--- a/cs251tk/toolkit/test_tabulate.py
+++ b/cs251tk/toolkit/test_tabulate.py
@@ -1,4 +1,5 @@
-from .tabulate import find_columns, pad, MISSING, concat, symbol, columnize, get_nums, sort_by_hw_count, sort_by_username
+from textwrap import dedent
+from .tabulate import find_columns, pad, MISSING, concat, symbol, columnize, get_nums, sort_by_hw_count, sort_by_username, tabulate
 
 
 def test_pad():
@@ -220,3 +221,51 @@ def test_sort_by_username():
     ]
 
     assert sorted(students, key=sort_by_username) == students
+
+
+def test_tabulate():
+    students = [
+        {
+            'username': 'rives3',
+            'homeworks': [
+                {'number': 1, 'status': 'success'},
+                {'number': 2, 'status': 'success'},
+                {'number': 3, 'status': 'success'},
+                {'number': 4, 'status': 'success'},
+            ],
+        },
+        {
+            'username': 'rives2',
+            'homeworks': [
+                {'number': 1, 'status': 'success'},
+                {'number': 2, 'status': 'success'},
+                {'number': 3, 'status': 'success'},
+            ],
+        },
+        {
+            'username': 'rives1',
+            'homeworks': [
+                {'number': 1, 'status': 'success'},
+                {'number': 2, 'status': 'success'},
+            ],
+            'labs': [
+                {'number': 1, 'status': 'success'},
+            ]
+        },
+    ]
+
+    assert tabulate(students) == dedent("""
+    USER    | 1 2 3 4 | 1
+    ---------------------
+    rives1  | 1 2 - - | 1
+    rives2  | 1 2 3 - | -
+    rives3  | 1 2 3 4 | -
+    """).strip()
+
+    assert tabulate(students, sort_by='count') == dedent("""
+    USER    | 1 2 3 4 | 1
+    ---------------------
+    rives3  | 1 2 3 4 | -
+    rives2  | 1 2 3 - | -
+    rives1  | 1 2 - - | 1
+    """).strip()

--- a/cs251tk/toolkit/test_tabulate.py
+++ b/cs251tk/toolkit/test_tabulate.py
@@ -165,25 +165,25 @@ def test_sort_by_hw_count():
         {
             'username': 'rives1',
             'homeworks': [
-                {'number': 1, 'status': 'complete'},
-                {'number': 2, 'status': 'complete'},
-                {'number': 3, 'status': 'complete'},
-                {'number': 4, 'status': 'complete'},
+                {'number': 1, 'status': 'success'},
+                {'number': 2, 'status': 'success'},
+                {'number': 3, 'status': 'success'},
+                {'number': 4, 'status': 'success'},
             ],
         },
         {
             'username': 'rives2',
             'homeworks': [
-                {'number': 1, 'status': 'complete'},
-                {'number': 2, 'status': 'complete'},
-                {'number': 3, 'status': 'complete'},
+                {'number': 1, 'status': 'success'},
+                {'number': 2, 'status': 'success'},
+                {'number': 3, 'status': 'success'},
             ],
         },
         {
             'username': 'rives3',
             'homeworks': [
-                {'number': 1, 'status': 'complete'},
-                {'number': 2, 'status': 'complete'},
+                {'number': 1, 'status': 'success'},
+                {'number': 2, 'status': 'success'},
             ],
         },
     ]
@@ -196,25 +196,25 @@ def test_sort_by_username():
         {
             'username': 'rives1',
             'homeworks': [
-                {'number': 1, 'status': 'complete'},
-                {'number': 2, 'status': 'complete'},
-                {'number': 3, 'status': 'complete'},
-                {'number': 4, 'status': 'complete'},
+                {'number': 1, 'status': 'success'},
+                {'number': 2, 'status': 'success'},
+                {'number': 3, 'status': 'success'},
+                {'number': 4, 'status': 'success'},
             ],
         },
         {
             'username': 'rives2',
             'homeworks': [
-                {'number': 1, 'status': 'complete'},
-                {'number': 2, 'status': 'complete'},
-                {'number': 3, 'status': 'complete'},
+                {'number': 1, 'status': 'success'},
+                {'number': 2, 'status': 'success'},
+                {'number': 3, 'status': 'success'},
             ],
         },
         {
             'username': 'rives3',
             'homeworks': [
-                {'number': 1, 'status': 'complete'},
-                {'number': 2, 'status': 'complete'},
+                {'number': 1, 'status': 'success'},
+                {'number': 2, 'status': 'success'},
             ],
         },
     ]

--- a/cs251tk/toolkit/test_tabulate.py
+++ b/cs251tk/toolkit/test_tabulate.py
@@ -1,4 +1,4 @@
-from .tabulate import find_columns, pad, MISSING, concat, symbol, columnize
+from .tabulate import find_columns, pad, MISSING, concat, symbol, columnize, get_nums
 
 
 def test_pad():
@@ -79,3 +79,75 @@ def test_columnize():
     }
 
     assert columnize(student3, 'rives', 2, 1) == "{username}  | {error}".format(**student3)
+
+
+def test_get_nums():
+    assert get_nums([
+        {
+            'username': 'rives',
+            'unmerged_branches': True,
+            'homeworks': [
+                {'number': 1, 'status': 'success'},
+                {'number': 2, 'status': 'success'},
+            ],
+            'labs': [
+                {'number': 1, 'status': 'success'},
+            ]
+        }
+    ]) == (2, 1)
+
+    assert get_nums([
+        {
+            'username': 'rives1',
+            'unmerged_branches': True,
+            'homeworks': [
+                {'number': 1, 'status': 'success'},
+                {'number': 2, 'status': 'success'},
+            ],
+            'labs': [
+                {'number': 1, 'status': 'success'},
+            ]
+        },
+        {
+            'username': 'rives2',
+            'unmerged_branches': True,
+            'homeworks': [
+                {'number': 8, 'status': 'success'},
+                {'number': 9, 'status': 'success'},
+            ],
+            'labs': [
+                {'number': 10, 'status': 'success'},
+            ]
+        }
+    ]) == (9, 10)
+
+    assert get_nums([
+        {
+            'username': 'student',
+            'unmerged_branches': True,
+            'homeworks': [],
+            'labs': [],
+        }
+    ]) == (0, 0)
+
+    assert get_nums([
+        {
+            'username': 'student',
+            'unmerged_branches': True,
+            'homeworks': [
+                {'number': 1, 'status': 'success'},
+            ],
+            'labs': [],
+        }
+    ]) == (1, 0)
+
+    assert get_nums([
+        {
+            'username': 'student',
+            'unmerged_branches': True,
+            'homeworks': [],
+            'labs': [
+                {'number': 1, 'status': 'success'},
+            ],
+        }
+    ]) == (0, 1)

--- a/cs251tk/toolkit/test_tabulate.py
+++ b/cs251tk/toolkit/test_tabulate.py
@@ -1,4 +1,4 @@
-from .tabulate import find_columns, pad, MISSING, concat, symbol, columnize, get_nums
+from .tabulate import find_columns, pad, MISSING, concat, symbol, columnize, get_nums, sort_by_hw_count, sort_by_username
 
 
 def test_pad():
@@ -151,3 +151,65 @@ def test_get_nums():
             ],
         }
     ]) == (0, 1)
+
+
+def test_sort_by_hw_count():
+    students = [
+        {
+            'username': 'rives1',
+            'homeworks': [
+                {'number': 1, 'status': 'complete'},
+                {'number': 2, 'status': 'complete'},
+                {'number': 3, 'status': 'complete'},
+                {'number': 4, 'status': 'complete'},
+            ],
+        },
+        {
+            'username': 'rives2',
+            'homeworks': [
+                {'number': 1, 'status': 'complete'},
+                {'number': 2, 'status': 'complete'},
+                {'number': 3, 'status': 'complete'},
+            ],
+        },
+        {
+            'username': 'rives3',
+            'homeworks': [
+                {'number': 1, 'status': 'complete'},
+                {'number': 2, 'status': 'complete'},
+            ],
+        },
+    ]
+
+    assert sorted(students, key=sort_by_hw_count) == list(reversed(students))
+
+
+def test_sort_by_username():
+    students = [
+        {
+            'username': 'rives1',
+            'homeworks': [
+                {'number': 1, 'status': 'complete'},
+                {'number': 2, 'status': 'complete'},
+                {'number': 3, 'status': 'complete'},
+                {'number': 4, 'status': 'complete'},
+            ],
+        },
+        {
+            'username': 'rives2',
+            'homeworks': [
+                {'number': 1, 'status': 'complete'},
+                {'number': 2, 'status': 'complete'},
+                {'number': 3, 'status': 'complete'},
+            ],
+        },
+        {
+            'username': 'rives3',
+            'homeworks': [
+                {'number': 1, 'status': 'complete'},
+                {'number': 2, 'status': 'complete'},
+            ],
+        },
+    ]
+
+    assert sorted(students, key=sort_by_username) == students

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,3 @@
-# content of: tox.ini , put in same dir as setup.py
-
 [tox]
 envlist = py35,py36
 


### PR DESCRIPTION
This PR also solves once-and-for-all the problem of `max() cannot find the max of an empty sequence` – it turns out that `max()` takes an optional named argument `default=`, which it can use when given an empty sequence. So. I wish I'd discovered that a long time ago…