### PR TITLE
Add --skip-update-check flag

### DIFF
--- a/cs251tk/cli/cs251tk.py
+++ b/cs251tk/cli/cs251tk.py
@@ -38,7 +38,7 @@ def make_progress_bar(students, no_progress=False):
 def main():
     args = process_args()
     basedir = getcwd()
-    current_version, new_version = update_available()
+    current_version, new_version = update_available(skip_update_check=args['skip_update_check'])
     if new_version:
         print('v{} is available: you have v{}. Try "pip3 install --no-cache --user --update cs251tk" to update.'.format(current_version, new_version))
 

--- a/cs251tk/toolkit/args.py
+++ b/cs251tk/toolkit/args.py
@@ -24,6 +24,8 @@ def get_args():
                         help='print the version of the toolkit')
     parser.add_argument('--debug', action='store_true',
                         help='enable debugging mode (throw errors, implies -w1)')
+    parser.add_argument('--skip-update-check', action='store_true',
+                        help='skips the pypi update check')
 
     specs = parser.add_argument_group('control the homework specs')
     specs.add_argument('--course', default='sd', choices=['sd', 'hd'],

--- a/cs251tk/toolkit/find_update.py
+++ b/cs251tk/toolkit/find_update.py
@@ -8,8 +8,10 @@ from .config import conf
 def get_all_versions(pkg='cs251tk'):
     # PyPI has these "simple" html pages. They're how pip does stuff.
     try:
-        req = requests.get('https://pypi.python.org/simple/{}'.format(pkg))
+        req = requests.get('https://pypi.python.org/simple/{}'.format(pkg), timeout=0.01)
     except requests.exceptions.ConnectionError:
+        return []
+    except requests.exceptions.Timeout:
         return []
 
     # Remove the first and last bits

--- a/cs251tk/toolkit/find_update.py
+++ b/cs251tk/toolkit/find_update.py
@@ -26,8 +26,8 @@ def get_all_versions(pkg='cs251tk'):
     return natsort.natsorted(set(versions))
 
 
-def update_available():
-    if not conf.needs_update_check():
+def update_available(skip_update_check=False):
+    if skip_update_check or not conf.needs_update_check():
         return version, None
 
     conf.set_last_update_check()


### PR DESCRIPTION
Sometimes, you just don't want it to look for an update.

@rye, you might want this for Docker?

This PR also adds an update check timeout.