### PR TITLE
No more args[]

### DIFF
--- a/cs251tk/toolkit/args.py
+++ b/cs251tk/toolkit/args.py
@@ -103,13 +103,20 @@ def get_students_from_args(*, input, all_sections, sections, students, _all_stud
 
     # sections are identified by only being one char long
     elif sections:
-        sections = []
-        for section in sections:
-            try:
-                sections.append(_all_students['section-' + section] or _all_students[section])
-            except KeyError:
-                warning('Section "{}" could not be found in ./students.txt'.format(section))
-        people = [student for group in sections for student in group]
+        collected = []
+        for section_name in sections:
+            student_set = []
+            prefixed = 'section-{}'.format(section_name)
+
+            if section_name in _all_students:
+                student_set = _all_students[section_name]
+            elif prefixed in _all_students:
+                student_set = _all_students[prefixed]
+            else:
+                warning('Neither section [section-{0}] nor [{0}] could not be found in ./students.txt'.format(section_name))
+
+            collected.append(student_set)
+        people = [student for group in collected for student in group]
 
     # sort students and remove any duplicates
     return sorted(set(people))

--- a/cs251tk/toolkit/process_student.py
+++ b/cs251tk/toolkit/process_student.py
@@ -8,29 +8,34 @@ from cs251tk.student import reset
 from cs251tk.student import analyze
 
 
-def process_student(student, args=None, specs=None, basedir=None, debug=False):
-    if not args:
-        raise Exception('`args` should not be none')
-    if not specs:
-        raise Exception('`specs` should not be none')
-    if not basedir:
-        raise Exception('`basedir` should not be none')
-
-    if args['clean']:
+def process_student(
+    student,
+    *,
+    assignments,
+    basedir,
+    clean,
+    date,
+    debug,
+    no_check,
+    no_update,
+    specs,
+    stogit_url
+):
+    if clean:
         remove(student)
 
-    clone_student(student, baseurl=args['stogit'])
+    clone_student(student, baseurl=stogit_url)
 
     try:
-        stash(student, no_update=args['no_update'])
-        pull(student, no_update=args['no_update'])
+        stash(student, no_update=no_update)
+        pull(student, no_update=no_update)
 
-        checkout_date(student, date=args['date'])
+        checkout_date(student, date=date)
 
-        recordings = record(student, specs, to_record=args['record'], basedir=basedir, debug=debug)
-        analysis = analyze(student, specs, check_for_branches=not args['no_check'])
+        recordings = record(student, specs, to_record=assignments, basedir=basedir, debug=debug)
+        analysis = analyze(student, specs, check_for_branches=not no_check)
 
-        if args['date']:
+        if date:
             reset(student)
 
         return analysis, recordings

--- a/cs251tk/toolkit/tabulate.py
+++ b/cs251tk/toolkit/tabulate.py
@@ -92,7 +92,7 @@ def get_nums(students):
     return max_hwk_num, max_lab_num
 
 
-def tabulate(students, sort_by='name', partials=False):
+def tabulate(students, sort_by='name', highlight_partials=False):
     """Actually build the table"""
 
     # be sure that the longest username will be at least 4 chars
@@ -127,7 +127,7 @@ def tabulate(students, sort_by='name', partials=False):
         sorter = sort_by_username
         should_reverse = False
 
-    lines = [columnize(student, longest_user, max_hwk_num, max_lab_num, highlight_partials=partials)
+    lines = [columnize(student, longest_user, max_hwk_num, max_lab_num, highlight_partials=highlight_partials)
              for student in sorted(students, reverse=should_reverse, key=sorter)]
 
     # and make the table to return

--- a/cs251tk/toolkit/test_args.py
+++ b/cs251tk/toolkit/test_args.py
@@ -1,3 +1,4 @@
+import datetime
 from .args import (
     build_argparser,
     get_students_from_args,
@@ -43,3 +44,20 @@ def test_section():
 
 def test_record():
     assert get_assignments_from_args(**args(['--record', 'hw4'])) == ['hw4']
+
+
+def test_stogit_url_computation():
+    assert compute_stogit_url(stogit=None, course='sd', _now=datetime.date(2017, 1, 31)) \
+        == 'git@stogit.cs.stolaf.edu:sd-s17'
+
+    assert compute_stogit_url(stogit=None, course='sd', _now=datetime.date(2016, 9, 15)) \
+        == 'git@stogit.cs.stolaf.edu:sd-f16'
+
+    assert compute_stogit_url(stogit=None, course='sd', _now=datetime.date(2016, 4, 15)) \
+        == 'git@stogit.cs.stolaf.edu:sd-s16'
+
+    assert compute_stogit_url(stogit='blah', course='sd', _now=datetime.date.today()) \
+        == 'blah'
+
+    assert compute_stogit_url(stogit=None, course='hd', _now=datetime.date(2016, 4, 15)) \
+        == 'git@stogit.cs.stolaf.edu:hd-s16'

--- a/cs251tk/toolkit/test_args.py
+++ b/cs251tk/toolkit/test_args.py
@@ -1,8 +1,13 @@
-from .args import get_args, massage_args
+from .args import (
+    build_argparser,
+    get_students_from_args,
+    get_assignments_from_args,
+    compute_stogit_url,
+)
 
 
 def args(arglist):
-    return vars(get_args().parse_args(args=arglist))
+    return vars(build_argparser().parse_args(args=arglist))
 
 
 students = {
@@ -13,32 +18,28 @@ students = {
 
 
 def test_all():
-    # check that --all sets `all` to true
-    assert massage_args(args([]), students)['all'] == False
-    assert massage_args(args(['--all']), students)['all'] == True
-
     # check that --all includes all students
-    assert massage_args(args(['--all']), students)['students'] == students['my'] + students['section-a'] + students['section-b']
+    assert get_students_from_args(**args(['--all']), _all_students=students) == students['my'] + students['section-a'] + students['section-b']
 
 
 def test_students():
     # multiple sets of --students should wind up as one flattened list
-    assert massage_args(args(['--students', 'a', 'b', '--students', 'c']), students)['students'] == ['a', 'b', 'c']
+    assert get_students_from_args(**args(['--students', 'a', 'b', '--students', 'c']), _all_students=students) == ['a', 'b', 'c']
 
     # it should return a sorted list of student names
-    assert massage_args(args(['--students', 'c', 'b', '--students', 'a']), students)['students'] == ['a', 'b', 'c']
+    assert get_students_from_args(**args(['--students', 'c', 'b', '--students', 'a']), _all_students=students) == ['a', 'b', 'c']
 
     # multiple occurences of the same student should be removed
-    assert massage_args(args(['--students', 'a', 'a', '--students', 'a']), students)['students'] == ['a']
+    assert get_students_from_args(**args(['--students', 'a', 'a', '--students', 'a']), _all_students=students) == ['a']
 
     # if no students are given, it should default to the "my" section
-    assert massage_args(args([]), students)['section'] == ['my']
+    assert get_students_from_args(**args([]), _all_students=students) == students['my']
 
 
 def test_section():
     # "--section $name" should return the students for that section
-    assert massage_args(args(['--section', 'a']), students)['students'] == students['section-a']
+    assert get_students_from_args(**args(['--section', 'a']), _all_students=students) == students['section-a']
 
 
 def test_record():
-    assert massage_args(args(['--record', 'hw4']), students)['record'] == ['hw4']
+    assert get_assignments_from_args(**args(['--record', 'hw4'])) == ['hw4']


### PR DESCRIPTION
The primary goal of this PR was to remove all uses of the `args[string]` pattern, where we treat `args` as this giant black boxed blob that we just pass around to any function that needs an argument.

Instead, this uses Python's keyword arguments features to allow the functions to require arguments.

```python
# This function will require that it is called with the named 
# parameters `a` and `b` explicitly set to something. It 
# will error if you try to use them as positional args.
def function(*, a, b):
    pass
```

This PR also splits `massage_args` into three functions: `get_students`, `get_assignments`, and `compute_stogit_url`, each of which now has a single responsibility, instead of the previous
situation where `massage_args` had all three jobs.
