### PR TITLE
Add checks for spec dependencies

### DIFF
--- a/cs251tk/specs/load.py
+++ b/cs251tk/specs/load.py
@@ -1,6 +1,7 @@
 from logging import warning
 from glob import iglob
 import json
+import os
 
 from .cache import cache_specs
 
@@ -31,7 +32,7 @@ def load_spec(filename):
     with open(filename, 'r', encoding='utf-8') as specfile:
         loaded_spec = json.load(specfile)
 
-    name = filename.split('/')[-1].split('.')[0]
+    name = os.path.splitext(os.path.basename(filename))[0]
     assignment = loaded_spec['assignment']
 
     if name != assignment:

--- a/cs251tk/specs/load.py
+++ b/cs251tk/specs/load.py
@@ -38,4 +38,7 @@ def load_spec(filename):
     if name != assignment:
         warning('assignment "{}" does not match the filename {}'.format(assignment, filename))
 
+    for filepath in loaded_spec.get('dependencies', []):
+        warning('spec {}: required file "{}" could not be found'.format(assignment, filepath))
+
     return assignment, loaded_spec


### PR DESCRIPTION
This PR adds checks for spec dependencies, as discussed in https://github.com/StoDevX/cs251-toolkit/issues/37: 

The current implementation simply prints a warning at program startup if the files cannot be found. We will need to add the "binary.h" file as a dependency of hw3 before this warning will be printed, though.