### PR TITLE
Cleanups

### DIFF
--- a/cs251tk/common/run.py
+++ b/cs251tk/common/run.py
@@ -1,6 +1,6 @@
+import subprocess
 import copy
 import os
-from subprocess import STDOUT, PIPE, run as _run, CalledProcessError, TimeoutExpired
 
 
 # This env stuff is to catch glibc errors, because
@@ -13,20 +13,20 @@ ENV["LIBC_FATAL_STDERR_"] = "1"
 def run(cmd, input_data=None, timeout=None):
     status = 'success'
     try:
-        result = _run(
+        result = subprocess.run(
             cmd,
-            stdout=PIPE,
-            stderr=STDOUT,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
             timeout=timeout,
             input=input_data,
             env=ENV,
             check=True)
 
-    except CalledProcessError as err:
+    except subprocess.CalledProcessError as err:
         status = 'called process error'
         result = err.output if err.output else str(err)
 
-    except TimeoutExpired as err:
+    except subprocess.TimeoutExpired as err:
         status = 'timed out after {} seconds'.format(timeout)
         result = err.output if err.output else str(err)
 

--- a/cs251tk/common/run.py
+++ b/cs251tk/common/run.py
@@ -3,8 +3,6 @@ import copy
 import os
 
 
-
-
 def run(cmd, input_data=None, timeout=None):
     status = 'success'
     try:

--- a/cs251tk/common/run.py
+++ b/cs251tk/common/run.py
@@ -3,11 +3,6 @@ import copy
 import os
 
 
-# This env stuff is to catch glibc errors, because
-# it apparently prints to /dev/tty instead of stderr.
-# (see http://stackoverflow.com/a/27797579)
-ENV = copy.copy(os.environ)
-ENV["LIBC_FATAL_STDERR_"] = "1"
 
 
 def run(cmd, input_data=None, timeout=None):
@@ -19,7 +14,7 @@ def run(cmd, input_data=None, timeout=None):
             stderr=subprocess.STDOUT,
             timeout=timeout,
             input=input_data,
-            env=ENV,
+            env=copy_env(),
             check=True)
 
     except subprocess.CalledProcessError as err:
@@ -51,3 +46,11 @@ def run(cmd, input_data=None, timeout=None):
         result = str(result, 'cp437')
 
     return (status, result)
+
+
+# This is to catch glibc errors, because it prints to /dev/tty
+# instead of stderr. See https://stackoverflow.com/a/27797579
+def copy_env():
+    env = copy.copy(os.environ)
+    env["LIBC_FATAL_STDERR_"] = "1"
+    return env

--- a/cs251tk/student/record.py
+++ b/cs251tk/student/record.py
@@ -11,7 +11,7 @@ def record(student, specs, to_record, basedir, debug):
 
     with chdir(student):
         for one_to_record in to_record:
-            logging.debug('recording', one_to_record)
+            logging.debug('recording {}'.format(one_to_record))
             if path.exists(one_to_record):
                 with chdir(one_to_record):
                     recording = markdownify(one_to_record, student, specs[one_to_record], basedir, debug)

--- a/cs251tk/toolkit/__main__.py
+++ b/cs251tk/toolkit/__main__.py
@@ -65,7 +65,7 @@ def main():
     logging.basicConfig(level=logging.DEBUG if debug else logging.WARNING)
 
     if date:
-        print('Checking out {}'.format(date))
+        logging.debug('Checking out {}'.format(date))
 
     specs = load_all_specs(basedir)
     if not specs:

--- a/cs251tk/toolkit/__main__.py
+++ b/cs251tk/toolkit/__main__.py
@@ -38,7 +38,7 @@ def make_progress_bar(students, no_progress=False):
 def main():
     basedir = getcwd()
 
-    args, students, assignments, stogit_url = process_args()
+    args, usernames, assignments, stogit_url = process_args()
     clean = args['clean']
     date = args['date']
     debug = args['debug']
@@ -72,7 +72,7 @@ def main():
         print('no specs loaded!')
         sys.exit(1)
 
-    print_progress = make_progress_bar(students, no_progress=no_progress)
+    print_progress = make_progress_bar(usernames, no_progress=no_progress)
 
     results = []
     records = []
@@ -93,7 +93,7 @@ def main():
 
         if workers > 1:
             with ProcessPoolExecutor(max_workers=workers) as pool:
-                futures = [pool.submit(single, student) for student in students]
+                futures = [pool.submit(single, name) for name in usernames]
                 for future in as_completed(futures):
                     result, recording = future.result()
                     print_progress(result['username'])
@@ -101,7 +101,7 @@ def main():
                     records.extend(recording)
 
         else:
-            for student in students:
+            for student in usernames:
                 result, recording = single(student)
                 print_progress(result['username'])
                 results.append(result)

--- a/cs251tk/toolkit/__main__.py
+++ b/cs251tk/toolkit/__main__.py
@@ -56,7 +56,11 @@ def main():
         workers = 1
     current_version, new_version = update_available(skip_update_check=skip_update_check)
     if new_version:
-        print('v{} is available: you have v{}. Try "pip3 install --no-cache --user --update cs251tk" to update.'.format(current_version, new_version))
+        print((
+            'v{} is available: you have v{}. '
+            'Try "pip3 install --no-cache --user --update cs251tk" '
+            'to update.'
+        ).format(current_version, new_version))
 
     logging.basicConfig(level=logging.DEBUG if debug else logging.WARNING)
 

--- a/cs251tk/toolkit/__main__.py
+++ b/cs251tk/toolkit/__main__.py
@@ -52,6 +52,8 @@ def main():
     sort_by = args['sort_by']
     workers = args['workers']
 
+    if debug:
+        workers = 1
     current_version, new_version = update_available(skip_update_check=skip_update_check)
     if new_version:
         print('v{} is available: you have v{}. Try "pip3 install --no-cache --user --update cs251tk" to update.'.format(current_version, new_version))
@@ -85,7 +87,7 @@ def main():
             stogit_url=stogit_url
         )
 
-        if workers > 1 and not debug:
+        if workers > 1:
             with ProcessPoolExecutor(max_workers=workers) as pool:
                 futures = [pool.submit(single, student) for student in students]
                 for future in as_completed(futures):

--- a/cs251tk/toolkit/args.py
+++ b/cs251tk/toolkit/args.py
@@ -2,7 +2,6 @@
 
 import datetime
 import argparse
-import textwrap
 import sys
 import re
 from os import cpu_count

--- a/cs251tk/toolkit/args.py
+++ b/cs251tk/toolkit/args.py
@@ -90,7 +90,7 @@ def get_students_from_args(*, input_items, all_sections, sections, students, _al
         sections = ['all']
 
     # fall back to the students.my section
-    if not students and not sections:
+    if not people and not sections:
         sections = ['my']
 
     # support 'my' students and 'all' students

--- a/cs251tk/toolkit/args.py
+++ b/cs251tk/toolkit/args.py
@@ -96,7 +96,7 @@ def get_students_from_args(*, input_items, all_sections, sections, students, _al
     if 'my' in sections:
         if 'my' not in _all_students:
             warning('There is no [my] section in students.txt')
-            return args
+            return sorted(set(people))
         people = _all_students['my']
 
     elif 'all' in sections:

--- a/cs251tk/toolkit/args.py
+++ b/cs251tk/toolkit/args.py
@@ -7,6 +7,7 @@ import re
 from os import cpu_count, getenv
 from logging import warning
 from natsort import natsorted
+from typing import List
 
 from cs251tk.common import flatten, version
 from .get_students import get_students as load_students_from_file
@@ -17,7 +18,7 @@ ASSIGNMENT_REGEX = re.compile(r'^(HW|LAB)', re.IGNORECASE)
 def build_argparser():
     """Construct the argument list and parse the passed arguments"""
     parser = argparse.ArgumentParser(description='The core of the CS251 toolkit')
-    parser.add_argument('input', nargs='*',
+    parser.add_argument('input_items', nargs='*', metavar='ITEM',
                         help='A mixed list of students and assignments')
     parser.add_argument('-v', '--version', action='store_true',
                         help='print the version of the toolkit')
@@ -75,8 +76,8 @@ def build_argparser():
     return parser
 
 
-def get_students_from_args(*, input, all_sections, sections, students, _all_students, **kwargs):
-    people = [l for l in input if not re.match(ASSIGNMENT_REGEX, l)]
+def get_students_from_args(*, input_items, all_sections, sections, students, _all_students, **kwargs) -> List[str]:
+    people = [l for l in input_items if not re.match(ASSIGNMENT_REGEX, l)]
 
     # argparser puts it into a nested list because you could have two
     # occurrences of the arg, each with a variable number of arguments.
@@ -122,9 +123,9 @@ def get_students_from_args(*, input, all_sections, sections, students, _all_stud
     return sorted(set(people))
 
 
-def get_assignments_from_args(*, input, to_record, **kwargs):
+def get_assignments_from_args(*, input_items, to_record, **kwargs) -> List[str]:
     # grab the assignments given on the plain args list
-    assignments = [l for l in input if re.match(ASSIGNMENT_REGEX, l)]
+    assignments = [l for l in input_items if re.match(ASSIGNMENT_REGEX, l)]
 
     # argparser puts --record into a nested list because you could have two
     # occurrences of the arg, each with a variable number of arguments.
@@ -135,7 +136,7 @@ def get_assignments_from_args(*, input, to_record, **kwargs):
     return natsorted(set(assignments))
 
 
-def compute_stogit_url(*, stogit, course, _now, **kwargs):
+def compute_stogit_url(*, stogit, course, _now, **kwargs) -> str:
     """calculate a default stogit URL, or use the specified one"""
     if stogit:
         return stogit

--- a/cs251tk/toolkit/args.py
+++ b/cs251tk/toolkit/args.py
@@ -63,7 +63,8 @@ def build_argparser():
 
     dates = parser.add_argument_group('time-based arguments')
     dates.add_argument('--date', action='store', metavar='GIT_DATE',
-                       help='Check out last submission on GIT_DATE (eg, "last week", "tea time", "2 hrs ago") (see `man git-rev-list`)')
+                       help=('Check out last submission on GIT_DATE (eg, "last week", "tea time", "2 hrs ago")'
+                             '(see `man git-rev-list`)'))
 
     grading = parser.add_argument_group('grading arguments')
     grading.add_argument('--no-check', '-c', action='store_true',
@@ -114,7 +115,10 @@ def get_students_from_args(*, input_items, all_sections, sections, students, _al
             elif prefixed in _all_students:
                 student_set = _all_students[prefixed]
             else:
-                warning('Neither section [section-{0}] nor [{0}] could not be found in ./students.txt'.format(section_name))
+                warning((
+                    'Neither section [section-{0}] nor [{0}] '
+                    'could not be found in ./students.txt'
+                ).format(section_name))
 
             collected.append(student_set)
         people = [student for group in collected for student in group]

--- a/cs251tk/toolkit/args.py
+++ b/cs251tk/toolkit/args.py
@@ -4,7 +4,7 @@ import datetime
 import argparse
 import sys
 import re
-from os import cpu_count
+from os import cpu_count, getenv
 from logging import warning
 from natsort import natsorted
 
@@ -24,6 +24,7 @@ def build_argparser():
     parser.add_argument('--debug', action='store_true',
                         help='enable debugging mode (throw errors, implies -w1)')
     parser.add_argument('--skip-update-check', action='store_true',
+                        default=getenv('CS251TK_SKIP_UPDATE_CHECK', False) is not False,
                         help='skips the pypi update check')
 
     specs = parser.add_argument_group('control the homework specs')

--- a/cs251tk/toolkit/get_students.py
+++ b/cs251tk/toolkit/get_students.py
@@ -12,7 +12,8 @@ def get_students():
     except FileNotFoundError:
         lines = []
 
-    lines = [l.strip() for l in lines if l.strip()]
+    lines = [l.strip() for l in lines]
+    lines = [l for l in lines if l]
     group_regex = re.compile(r'\[.*\]')
     group_list = [clean_header(l) for l in lines if group_regex.match(l)]
     if not group_list:

--- a/cs251tk/toolkit/process_student.py
+++ b/cs251tk/toolkit/process_student.py
@@ -41,4 +41,6 @@ def process_student(
         return analysis, recordings
 
     except Exception as err:
+        if debug:
+            raise err
         return {'username': student, 'error': err}, []


### PR DESCRIPTION
- Added support for the `CS251TK_SKIP_UPDATE_CHECK` environment variable to skip the update check
- Added some type annotations to `toolkit/args.py`
- Make a fresh copy of the environment for each invocation of subprocess.run
- Fix a logic error in `toolkit/args.py` that prevented you from specifying a single student to check
- Made debugging easier by `raise`ing errors that arise in the student checking