### PR TITLE
Spec dependent file check fixes

### DIFF
--- a/cs251tk/specs/__init__.py
+++ b/cs251tk/specs/__init__.py
@@ -1,3 +1,4 @@
 from .load import load_all_specs
 from .load import load_some_specs
 from .util import get_filenames
+from .util import check_dependencies

--- a/cs251tk/specs/load.py
+++ b/cs251tk/specs/load.py
@@ -39,6 +39,9 @@ def load_spec(filename):
         warning('assignment "{}" does not match the filename {}'.format(assignment, filename))
 
     for filepath in loaded_spec.get('dependencies', []):
-        warning('spec {}: required file "{}" could not be found'.format(assignment, filepath))
+        try:
+            os.stat(filepath)
+        except FileNotFoundError:
+            warning('spec {}: required file "{}" could not be found'.format(assignment, filepath))
 
     return assignment, loaded_spec

--- a/cs251tk/specs/load.py
+++ b/cs251tk/specs/load.py
@@ -4,7 +4,6 @@ import json
 import os
 
 from .cache import cache_specs
-from .util import check_dependencies
 
 
 def load_all_specs(basedir='.'):
@@ -38,7 +37,5 @@ def load_spec(filename):
 
     if name != assignment:
         warning('assignment "{}" does not match the filename {}'.format(assignment, filename))
-
-    check_dependencies(loaded_spec)
 
     return assignment, loaded_spec

--- a/cs251tk/specs/load.py
+++ b/cs251tk/specs/load.py
@@ -4,6 +4,7 @@ import json
 import os
 
 from .cache import cache_specs
+from .util import check_dependencies
 
 
 def load_all_specs(basedir='.'):
@@ -38,10 +39,6 @@ def load_spec(filename):
     if name != assignment:
         warning('assignment "{}" does not match the filename {}'.format(assignment, filename))
 
-    for filepath in loaded_spec.get('dependencies', []):
-        try:
-            os.stat(filepath)
-        except FileNotFoundError:
-            warning('spec {}: required file "{}" could not be found'.format(assignment, filepath))
+    check_dependencies(loaded_spec)
 
     return assignment, loaded_spec

--- a/cs251tk/specs/util.py
+++ b/cs251tk/specs/util.py
@@ -1,3 +1,15 @@
+import os
+from logging import warning
+
+
 def get_filenames(spec):
     """returns the list of files from an assignment spec"""
     return [file['filename'] for file in spec['files']]
+
+
+def check_dependencies(spec):
+    for filepath in spec.get('dependencies', []):
+        try:
+            os.stat(filepath)
+        except FileNotFoundError:
+            warning('spec {}: required file "{}" could not be found'.format(spec['assignment'], filepath))

--- a/cs251tk/toolkit/__main__.py
+++ b/cs251tk/toolkit/__main__.py
@@ -5,7 +5,7 @@ from concurrent.futures import ProcessPoolExecutor, as_completed
 from os import makedirs, getcwd
 
 from ..common import chdir
-from ..specs import load_all_specs
+from ..specs import load_all_specs, check_dependencies
 from .find_update import update_available
 from .process_student import process_student
 from .args import process_args
@@ -71,6 +71,9 @@ def main():
     if not specs:
         print('no specs loaded!')
         sys.exit(1)
+
+    for spec_to_use in assignments:
+        check_dependencies(specs[spec_to_use])
 
     print_progress = make_progress_bar(usernames, no_progress=no_progress)
 


### PR DESCRIPTION
So, ah, I realized that the spec dependency check … wasn't actually checking anything.

So this fixes that.

This also moves the check into main(), so we can only check the specs we're actually going to use.

Closes #52.