### PR TITLE
Allow interacting with submissions

### DIFF
--- a/cs251tk/common/find_unmerged_branches_in_cwd.py
+++ b/cs251tk/common/find_unmerged_branches_in_cwd.py
@@ -4,7 +4,7 @@ from .run import run
 # TODO: This is a bit slow. Look for a faster way to check.
 def find_unmerged_branches_in_cwd():
     """Check for unmerged branches in the current repository"""
-    _, unmerged_branches = run(['git', 'branch', '-a', '--no-merged', 'master'])
+    _, unmerged_branches, _ = run(['git', 'branch', '-a', '--no-merged', 'master'])
     return [s.strip()
             for s in unmerged_branches.split('\n')
             if s.strip()]

--- a/cs251tk/common/run.py
+++ b/cs251tk/common/run.py
@@ -32,9 +32,12 @@ def run_interactive(cmd):
         except UnicodeDecodeError:
             result = script.getvalue().decode(encoding='cp437')
 
-    print('\nSubmission recording completed.', end='\n\n')
+    print('\nSubmission recording completed.')
 
-    return (status, result)
+    runagain = input('Do you want to run the submission again? [y/N]: ')
+    again = runagain.lower().startswith('y')
+
+    return (status, result, again)
 
 
 def run_static(cmd, input_data=None, timeout=None):
@@ -77,7 +80,7 @@ def run_static(cmd, input_data=None, timeout=None):
     except UnicodeDecodeError:
         result = str(result, 'cp437')
 
-    return (status, result)
+    return (status, result, False)
 
 
 # This is to catch glibc errors, because it prints to /dev/tty

--- a/cs251tk/common/run.py
+++ b/cs251tk/common/run.py
@@ -3,7 +3,11 @@ import copy
 import os
 
 
-def run(cmd, input_data=None, timeout=None, interact=False):
+def run(cmd, *, interact=False, **kwargs):
+    return run_static(cmd, **kwargs)
+
+
+def run_static(cmd, input_data=None, timeout=None):
     status = 'success'
     try:
         result = subprocess.run(

--- a/cs251tk/common/run.py
+++ b/cs251tk/common/run.py
@@ -32,7 +32,7 @@ def run_interactive(cmd):
         except UnicodeDecodeError:
             result = script.getvalue().decode(encoding='cp437')
 
-    print('Submission recording completed.', end='\n\n')
+    print('\nSubmission recording completed.', end='\n\n')
 
     return (status, result)
 

--- a/cs251tk/common/run.py
+++ b/cs251tk/common/run.py
@@ -3,7 +3,7 @@ import copy
 import os
 
 
-def run(cmd, input_data=None, timeout=None):
+def run(cmd, input_data=None, timeout=None, interact=False):
     status = 'success'
     try:
         result = subprocess.run(

--- a/cs251tk/common/run.py
+++ b/cs251tk/common/run.py
@@ -15,7 +15,7 @@ def run_interactive(cmd):
     status = 'success'
     result = None
 
-    print('Recording submission. Send EOF (^D) to end.', end='\n\n')
+    print('Recording {}. Send EOF (^D) to end.'.format(cmd), end='\n\n')
 
     # This is mostly taken from the stdlib's `pty` docs
     with io.BytesIO() as script:

--- a/cs251tk/common/test_run.py
+++ b/cs251tk/common/test_run.py
@@ -2,24 +2,28 @@ from .run import run
 
 
 def test_run():
-    status, result = run(['echo', 'hi'])
+    status, result, again = run(['echo', 'hi'])
     assert status == 'success'
     assert result == 'hi\n'
+    assert again == False
 
 
 def test_run_stdin():
-    status, result = run(['cat'], input_data=b'hello')
+    status, result, again = run(['cat'], input_data=b'hello')
     assert status == 'success'
     assert result == 'hello'
+    assert again == False
 
 
 def test_run_timeout():
-    status, result = run(['sleep', '1'], timeout=0.5)
+    status, result, again = run(['sleep', '1'], timeout=0.5)
     assert status == 'timed out after 0.5 seconds'
     assert result == "Command '['sleep', '1']' timed out after 0.5 seconds"
+    assert again == False
 
 
 def test_run_not_found():
-    status, result = run(['notfound'])
+    status, result, again = run(['notfound'])
     assert status == 'not found'
     assert result == "[Errno 2] No such file or directory: 'notfound'"
+    assert again == False

--- a/cs251tk/student/checkout.py
+++ b/cs251tk/student/checkout.py
@@ -5,7 +5,7 @@ from cs251tk.common import run
 def checkout_date(student, date=None):
     if date:
         with chdir(student):
-            _, rev = run(['git', 'rev-list', '-n', '1', '--before="{} 18:00"'.format(date), 'master'])
+            _, rev, _ = run(['git', 'rev-list', '-n', '1', '--before="{} 18:00"'.format(date), 'master'])
             run(['git', 'checkout', rev, '--force', '--quiet'])
 
 

--- a/cs251tk/student/clone.py
+++ b/cs251tk/student/clone.py
@@ -10,5 +10,5 @@ def clone_student(student, baseurl):
 
 def clone_url(url):
     logging.info('cloning {}'.format(url))
-    _, output = run(['git', 'clone', '--quiet', url])
+    _, output, _ = run(['git', 'clone', '--quiet', url])
     logging.debug(output)

--- a/cs251tk/student/markdownify/markdownify.py
+++ b/cs251tk/student/markdownify/markdownify.py
@@ -6,7 +6,7 @@ from .process_file import process_file
 from .find_warnings import find_warnings
 
 
-def markdownify(spec_id, username, spec, basedir, debug):
+def markdownify(spec_id, *, username, spec, basedir, debug, interact):
     """Run a spec against the current folder"""
     try:
         cwd = os.getcwd()
@@ -31,7 +31,13 @@ def markdownify(spec_id, username, spec, basedir, debug):
             filename = file['filename']
             steps = file['commands']
             options = file['options']
-            result = process_file(filename, steps, options, spec, cwd, supporting)
+            result = process_file(filename,
+                                  steps=steps,
+                                  options=options,
+                                  spec=spec,
+                                  cwd=cwd,
+                                  supporting_dir=supporting,
+                                  interact=interact)
             results['files'][filename] = result
 
         # now we remove any compiled binaries

--- a/cs251tk/student/markdownify/pipe.py
+++ b/cs251tk/student/markdownify/pipe.py
@@ -32,7 +32,7 @@ def pipe(cmd_string):
 
     input_for_cmd = None
     for cmd in cmds[:-1]:
-        _, input_for_cmd = run(process_chunk(cmd), input_data=input_for_cmd)
+        _, input_for_cmd, _ = run(process_chunk(cmd), input_data=input_for_cmd)
         input_for_cmd = input_for_cmd.encode('utf-8')
 
     final_cmd = process_chunk(cmds[-1])

--- a/cs251tk/student/markdownify/process_file.py
+++ b/cs251tk/student/markdownify/process_file.py
@@ -65,21 +65,23 @@ def test_file(filename, *, spec, results, options, cwd, supporting_dir, interact
         test_cmd, input_for_test = pipe(test_cmd)
 
         if os.path.exists(os.path.join(cwd, filename)):
-            status, full_result = run(test_cmd,
-                                      input_data=input_for_test,
-                                      timeout=options['timeout'],
-                                      interact=interact)
+            again = True
+            while again:
+                status, full_result, again = run(test_cmd,
+                                                 input_data=input_for_test,
+                                                 timeout=options['timeout'],
+                                                 interact=interact)
 
-            result = truncate(full_result, options['truncate_output'])
-            truncated = (full_result != result)
+                result = truncate(full_result, options['truncate_output'])
+                was_truncated = (full_result != result)
 
-            results['result'].append({
-                'command': test_cmd,
-                'status': status,
-                'output': result,
-                'truncated': True if truncated else False,
-                'truncated after': options['truncate_output'],
-            })
+                results['result'].append({
+                    'command': test_cmd,
+                    'status': status,
+                    'output': result,
+                    'truncated': was_truncated,
+                    'truncated after': options['truncate_output'],
+                })
 
         else:
             results['result'].append({

--- a/cs251tk/student/markdownify/process_file.py
+++ b/cs251tk/student/markdownify/process_file.py
@@ -49,7 +49,7 @@ def compile_file(filename, steps, results, supporting_dir):
     return True
 
 
-def test_file(filename, spec, results, options, cwd, supporting_dir):
+def test_file(filename, *, spec, results, options, cwd, supporting_dir, interact):
     tests = flatten([test_spec['commands']
                      for test_spec in spec.get('tests', {})
                      if test_spec['filename'] == filename])
@@ -67,7 +67,8 @@ def test_file(filename, spec, results, options, cwd, supporting_dir):
         if os.path.exists(os.path.join(cwd, filename)):
             status, full_result = run(test_cmd,
                                       input_data=input_for_test,
-                                      timeout=options['timeout'])
+                                      timeout=options['timeout'],
+                                      interact=interact)
 
             result = truncate(full_result, options['truncate_output'])
             truncated = (full_result != result)
@@ -90,7 +91,7 @@ def test_file(filename, spec, results, options, cwd, supporting_dir):
     return True
 
 
-def process_file(filename, steps, options, spec, cwd, supporting_dir):
+def process_file(filename, *, steps, options, spec, cwd, supporting_dir, interact):
     steps = steps if isinstance(steps, Iterable) else [steps]
 
     base_opts = {
@@ -118,7 +119,13 @@ def process_file(filename, steps, options, spec, cwd, supporting_dir):
     if not should_continue or not steps:
         return results
 
-    should_continue = test_file(filename, spec, results, options, cwd, supporting_dir)
+    should_continue = test_file(filename,
+                                spec=spec,
+                                results=results,
+                                options=options,
+                                cwd=cwd,
+                                supporting_dir=supporting_dir,
+                                interact=interact)
     if not should_continue:
         return results
 

--- a/cs251tk/student/markdownify/process_file.py
+++ b/cs251tk/student/markdownify/process_file.py
@@ -10,7 +10,7 @@ from .pipe import pipe
 def get_file(filename, results, options):
     file_status, file_contents = cat(filename)
     if file_status == 'success':
-        _, last_edit = run(['git', 'log', '-n', '1', '--pretty=format:%cd', '--', filename])
+        _, last_edit, _ = run(['git', 'log', '-n', '1', '--pretty=format:%cd', '--', filename])
         results['last modified'] = last_edit
 
     if options['hide_contents']:
@@ -35,7 +35,7 @@ def compile_file(filename, steps, results, supporting_dir):
             .replace('$SUPPORT', supporting_dir)
 
         cmd, input_for_cmd = pipe(command)
-        status, compilation = run(cmd, input_data=input_for_cmd)
+        status, compilation, _ = run(cmd, input_data=input_for_cmd)
 
         results['compilation'].append({
             'command': command,

--- a/cs251tk/student/record.py
+++ b/cs251tk/student/record.py
@@ -4,7 +4,7 @@ from cs251tk.common import chdir
 from cs251tk.student.markdownify import markdownify
 
 
-def record(student, specs, to_record, basedir, debug):
+def record(student, *, specs, to_record, basedir, debug, interact):
     recordings = []
     if not to_record:
         return recordings
@@ -14,7 +14,12 @@ def record(student, specs, to_record, basedir, debug):
             logging.debug('recording {}'.format(one_to_record))
             if path.exists(one_to_record):
                 with chdir(one_to_record):
-                    recording = markdownify(one_to_record, student, specs[one_to_record], basedir, debug)
+                    recording = markdownify(one_to_record,
+                                            username=student,
+                                            spec=specs[one_to_record],
+                                            basedir=basedir,
+                                            debug=debug,
+                                            interact=interact)
             else:
                 recording = {
                     'spec': one_to_record,

--- a/cs251tk/student/stash.py
+++ b/cs251tk/student/stash.py
@@ -10,5 +10,5 @@ def stash(student, no_update):
 
 
 def has_changed_files():
-    _, output = run(['git', 'status', '--porcelain'])
+    _, output, _ = run(['git', 'status', '--porcelain'])
     return bool(output)

--- a/cs251tk/toolkit/__main__.py
+++ b/cs251tk/toolkit/__main__.py
@@ -44,6 +44,7 @@ def main():
     debug = args['debug']
     gist = args['gist']
     highlight_partials = args['highlight_partials']
+    interact = args['interact']
     no_check = args['no_check']
     no_update = args['no_update']
     no_progress = args['no_progress']
@@ -54,6 +55,9 @@ def main():
 
     if debug:
         workers = 1
+    if interact:
+        workers = 1
+
     current_version, new_version = update_available(skip_update_check=skip_update_check)
     if new_version:
         print((
@@ -85,6 +89,7 @@ def main():
             clean=clean,
             date=date,
             debug=debug,
+            interact=interact,
             no_check=no_check,
             no_update=no_update,
             specs=specs,

--- a/cs251tk/toolkit/args.py
+++ b/cs251tk/toolkit/args.py
@@ -73,6 +73,8 @@ def build_argparser():
                          help='Record information on student submissions. Requires a spec file')
     grading.add_argument('--gist', action='store_true',
                          help='Post overview table and student recordings as a private gist')
+    grading.add_argument('--interact', action='store_true',
+                         help="Interact with each student's submission individually")
 
     return parser
 

--- a/cs251tk/toolkit/process_student.py
+++ b/cs251tk/toolkit/process_student.py
@@ -16,6 +16,7 @@ def process_student(
     clean,
     date,
     debug,
+    interact,
     no_check,
     no_update,
     specs,
@@ -32,7 +33,7 @@ def process_student(
 
         checkout_date(student, date=date)
 
-        recordings = record(student, specs, to_record=assignments, basedir=basedir, debug=debug)
+        recordings = record(student, specs=specs, to_record=assignments, basedir=basedir, debug=debug, interact=interact)
         analysis = analyze(student, specs, check_for_branches=not no_check)
 
         if date:


### PR DESCRIPTION
TL;DR: `cs251tk --interact`.

---

Some submissions require interaction with the program to properly evaluate them, such as the story assignments from homeworks 4 and 5.

This PR adds the `--interact` flag, which runs one submission at a time, dropping you into a psuedo-tty (I think) where you can interact with the submitted program.

When the program is done, you can send EOF (<kbd>^D</kbd>, control-D) to exit the interaction.

After each interaction, you can easily run the submission again by answering the question "Do you want to run the submission again? [y/N]", which defaults to "no". (Examples of when you might want to run it again: `countup.cpp`, `countdown.cpp`.)

This mode offers no infinite loop protection, but <kbd>^C</kbd> should exit the submitted program while keeping the toolkit alive. In theory.

This mode will be refined based on feedback from the graders.

Closes #54.