### PR TITLE
Timeout on compilation after 30 seconds

### DIFF
--- a/cs251tk/student/markdownify/process_file.py
+++ b/cs251tk/student/markdownify/process_file.py
@@ -35,7 +35,7 @@ def compile_file(filename, steps, results, supporting_dir):
             .replace('$SUPPORT', supporting_dir)
 
         cmd, input_for_cmd = pipe(command)
-        status, compilation, _ = run(cmd, input_data=input_for_cmd)
+        status, compilation, _ = run(cmd, timeout=30, input_data=input_for_cmd)
 
         results['compilation'].append({
             'command': command,


### PR DESCRIPTION
*Closes #68*.

This PR adds `timeout=30` to the compilation command run.  I don't think there's a need to configure this variable.  This is the same as how we do running, so yeah.