### PR TITLE
Use the -t flag to allocate a Pseudo-TTY when running

### DIFF
--- a/script/run-docker
+++ b/script/run-docker
@@ -4,7 +4,7 @@
 docker=$(which docker)
 
 # Start writing out the command.
-command="$docker run -i"
+command="$docker run -it"
 
 default_CS251TK_IMAGE=stodevx/cs251-toolkit:HEAD
 default_CS251TK_SHARE=$HOME/.cs251tk_share


### PR DESCRIPTION
This will let us use the full width of the terminal rather than just assuming an 80-col limit.

I think I had removed these previously, but whatever.