### PR TITLE
Allow travis to reroute our builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 ---
-sudo: false
 dist: trusty
 
 language: python


### PR DESCRIPTION
TravisCI is moving away from these images; IIRC, sometime in November `sudo: false` will just have no effect anymore.