### PR TITLE
Fix update check

### DIFF
--- a/cs251tk/toolkit/__main__.py
+++ b/cs251tk/toolkit/__main__.py
@@ -63,8 +63,7 @@ def main():
         print((
             'v{} is available: you have v{}. '
             'Try "pip3 install --no-cache --user --upgrade cs251tk" '
-            'to update.'
-        ).format(new_version, current_version))
+            'to update.').format(new_version, current_version), file=sys.stderr)
 
     logging.basicConfig(level=logging.DEBUG if debug else logging.WARNING)
 

--- a/cs251tk/toolkit/__main__.py
+++ b/cs251tk/toolkit/__main__.py
@@ -62,9 +62,9 @@ def main():
     if new_version:
         print((
             'v{} is available: you have v{}. '
-            'Try "pip3 install --no-cache --user --update cs251tk" '
+            'Try "pip3 install --no-cache --user --upgrade cs251tk" '
             'to update.'
-        ).format(current_version, new_version))
+        ).format(new_version, current_version))
 
     logging.basicConfig(level=logging.DEBUG if debug else logging.WARNING)
 

--- a/cs251tk/toolkit/find_update.py
+++ b/cs251tk/toolkit/find_update.py
@@ -13,6 +13,7 @@ def get_all_versions(pkg='cs251tk'):
         return []
     except requests.exceptions.Timeout:
         return []
+    
     # Remove the first and last bits
     page = re.sub(r'.*</h1>|<br/>.*', '', req.text)
     # Grab just the links from the page

--- a/cs251tk/toolkit/find_update.py
+++ b/cs251tk/toolkit/find_update.py
@@ -13,7 +13,7 @@ def get_all_versions(pkg='cs251tk'):
         return []
     except requests.exceptions.Timeout:
         return []
-    
+
     # Remove the first and last bits
     page = re.sub(r'.*</h1>|<br/>.*', '', req.text)
     # Grab just the links from the page

--- a/cs251tk/toolkit/find_update.py
+++ b/cs251tk/toolkit/find_update.py
@@ -8,16 +8,15 @@ from .config import conf
 def get_all_versions(pkg='cs251tk'):
     # PyPI has these "simple" html pages. They're how pip does stuff.
     try:
-        req = requests.get('https://pypi.python.org/simple/{}'.format(pkg), timeout=0.01)
+        req = requests.get('https://pypi.python.org/simple/{}'.format(pkg), timeout=0.5)
     except requests.exceptions.ConnectionError:
         return []
     except requests.exceptions.Timeout:
         return []
-
     # Remove the first and last bits
     page = re.sub(r'.*</h1>|<br/>.*', '', req.text)
     # Grab just the links from the page
-    lines = [l for l in page.splitlines() if l.startswith('<a')]
+    lines = [l for l in page.splitlines() if l.strip().startswith('<a')]
     # Grab just the middles of the links
     packages = [re.sub('.*>(.*)<.*', '\\1', l) for l in lines]
     # Remove the suffixes

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ if sys.version_info < (3, 5):
 
 setup(
     name='cs251tk',
-    version='2.3.3',
+    version='2.3.0',
     description='The CS251 (Software Design) Toolkit',
     author='Hawken Rives',
     author_email='hawkrives@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ if sys.version_info < (3, 5):
 
 setup(
     name='cs251tk',
-    version='2.3.3',
+    version='2.3.4',
     description='The CS251 (Software Design) Toolkit',
     author='Hawken Rives',
     author_email='hawkrives@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ if sys.version_info < (3, 5):
 
 setup(
     name='cs251tk',
-    version='2.3.2',
+    version='2.3.3',
     description='The CS251 (Software Design) Toolkit',
     author='Hawken Rives',
     author_email='hawkrives@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ if sys.version_info < (3, 5):
 
 setup(
     name='cs251tk',
-    version='2.3.4',
+    version='2.3.3',
     description='The CS251 (Software Design) Toolkit',
     author='Hawken Rives',
     author_email='hawkrives@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ if sys.version_info < (3, 5):
 
 setup(
     name='cs251tk',
-    version='2.3.0',
+    version='2.3.3',
     description='The CS251 (Software Design) Toolkit',
     author='Hawken Rives',
     author_email='hawkrives@gmail.com',


### PR DESCRIPTION
- Added a `strip()` before lines are checked to see if they begin with `'<a'` - this was the main issue
- Increased timeout to 0.5s (from 0.01s) - 0.5 was the lowest reliable time I found. Maybe could be higher for slower connections.
- Reordered arguments in `main` (it said your current version was available and that you have the new version)
- Change `--update` to `--upgrade` in output
- Changed "update available" message to print to stderr