### PR TITLE
Fix date check

### DIFF
--- a/cs251tk/common/__init__.py
+++ b/cs251tk/common/__init__.py
@@ -1,4 +1,5 @@
 from .chdir import chdir
+from .check_submit_date import check_dates
 from .dirsize import dirsize
 from .find_unmerged_branches_in_cwd import find_unmerged_branches_in_cwd
 from .flatten import flatten

--- a/cs251tk/common/check_submit_date.py
+++ b/cs251tk/common/check_submit_date.py
@@ -1,6 +1,6 @@
 import os
 from dateutil.parser import parse
-from cs251tk.common import run, chdir
+from ..common import run, chdir
 
 
 def check_dates(spec_id, username, spec, basedir):

--- a/cs251tk/common/check_submit_date.py
+++ b/cs251tk/common/check_submit_date.py
@@ -17,6 +17,7 @@ def check_dates(spec_id, username, spec, basedir):
             # Run a git log on each file with earliest commits listed first
             status, res, _ = run(['git', 'log', '--reverse', '--pretty=format:%ad', '--date=iso8601',
                                   os.path.join(basedir, file['filename'])])
+
             # If we didn't get an error and got an output, add date to array
             if status == 'success' and res:
                 # Parse the first line

--- a/cs251tk/common/check_submit_date.py
+++ b/cs251tk/common/check_submit_date.py
@@ -1,6 +1,6 @@
 import os
 from dateutil.parser import parse
-from ...common import run, chdir
+from cs251tk.common import run, chdir
 
 
 def check_dates(spec_id, username, spec, basedir):

--- a/cs251tk/common/check_submit_date.py
+++ b/cs251tk/common/check_submit_date.py
@@ -27,4 +27,5 @@ def check_dates(spec_id, username, spec, basedir):
     # Return earliest date as a string with the format mm/dd/yyyy hh:mm:ss
     if not dates:
         return "ERROR"
+    
     return min(dates).strftime("%x %X")

--- a/cs251tk/common/check_submit_date.py
+++ b/cs251tk/common/check_submit_date.py
@@ -27,5 +27,5 @@ def check_dates(spec_id, username, spec, basedir):
     # Return earliest date as a string with the format mm/dd/yyyy hh:mm:ss
     if not dates:
         return "ERROR"
-    
+
     return min(dates).strftime("%x %X")

--- a/cs251tk/common/check_submit_date.py
+++ b/cs251tk/common/check_submit_date.py
@@ -11,16 +11,14 @@ def check_dates(spec_id, username, spec, basedir):
 
     basedir = os.path.join(basedir, 'students', username, spec_id)
     dates = []
-
     with chdir(basedir):
         for file in spec['files']:
 
             # Run a git log on each file with earliest commits listed first
             status, res, _ = run(['git', 'log', '--reverse', '--pretty=format:%ad', '--date=iso8601',
-                                 os.path.join(basedir, file['filename'])])
-
-            # If we didn't get an error, add date to array
-            if status == 'success':
+                                  os.path.join(basedir, file['filename'])])
+            # If we didn't get an error and got an output, add date to array
+            if status == 'success' and res:
                 # Parse the first line
                 dates.append(parse(res.splitlines()[0]))
 

--- a/cs251tk/common/check_submit_date.py
+++ b/cs251tk/common/check_submit_date.py
@@ -11,7 +11,7 @@ def check_dates(spec_id, username, spec, basedir):
 
     basedir = os.path.join(basedir, 'students', username, spec_id)
     dates = []
-    
+
     with chdir(basedir):
         for file in spec['files']:
 

--- a/cs251tk/common/check_submit_date.py
+++ b/cs251tk/common/check_submit_date.py
@@ -16,7 +16,7 @@ def check_dates(spec_id, username, spec, basedir):
 
             # Run a git log on each file with earliest commits listed first
             status, res, _ = run(['git', 'log', '--reverse', '--pretty=format:%ad', '--date=iso8601',
-                                  os.path.join(basedir, file['filename'])])
+                                 os.path.join(basedir, file['filename'])])
 
             # If we didn't get an error and got an output, add date to array
             if status == 'success' and res:

--- a/cs251tk/common/check_submit_date.py
+++ b/cs251tk/common/check_submit_date.py
@@ -11,6 +11,7 @@ def check_dates(spec_id, username, spec, basedir):
 
     basedir = os.path.join(basedir, 'students', username, spec_id)
     dates = []
+    
     with chdir(basedir):
         for file in spec['files']:
 

--- a/cs251tk/student/markdownify/check_submit_date.py
+++ b/cs251tk/student/markdownify/check_submit_date.py
@@ -25,4 +25,6 @@ def check_dates(spec_id, username, spec, basedir):
                 dates.append(parse(res.splitlines()[0]))
 
     # Return earliest date as a string with the format mm/dd/yyyy hh:mm:ss
+    if not dates:
+        return "ERROR"
     return min(dates).strftime("%x %X")

--- a/cs251tk/student/markdownify/markdownify.py
+++ b/cs251tk/student/markdownify/markdownify.py
@@ -4,7 +4,7 @@ import os
 from collections import OrderedDict
 from .process_file import process_file
 from .find_warnings import find_warnings
-from ...common.check_submit_date import check_dates
+from ...common import check_dates
 
 
 def markdownify(spec_id, *, username, spec, basedir, debug, interact):

--- a/cs251tk/student/markdownify/markdownify.py
+++ b/cs251tk/student/markdownify/markdownify.py
@@ -4,7 +4,7 @@ import os
 from collections import OrderedDict
 from .process_file import process_file
 from .find_warnings import find_warnings
-from .check_submit_date import check_dates
+from ...common.check_submit_date import check_dates
 
 
 def markdownify(spec_id, *, username, spec, basedir, debug, interact):


### PR DESCRIPTION
Fixes #92.
Fixes two problems:
- If the student doesn't commit any files listed in the spec but still created the directory, returns ERROR as the date instead of throwing an exception at `return min(dates).strftime("%x %X")`.
- If the student committed a file with the wrong capitalization (which causes `git log` to print nothing), don't allow `dates.append(parse(res.splitlines()[0]))` to run which would cause an exception.

Moved `check_submit_date.py` to common.