### PR TITLE
Improve first run experience for users

### DIFF
--- a/cs251tk/toolkit/__main__.py
+++ b/cs251tk/toolkit/__main__.py
@@ -98,10 +98,6 @@ def main():
     for spec_to_use in assignments:
         check_dependencies(specs[spec_to_use])
 
-    if not os.path.exists("students.txt"):
-        print("students.txt not found", file=sys.stderr)
-        sys.exit(1)
-
     results = []
     records = []
     makedirs('./students', exist_ok=True)


### PR DESCRIPTION
A HD TA contacted me this weekend asking why the toolkit wasn't setting up the student directories properly. The reason was because he forgot to include the `--course hd` flag. This prevents that from happening by changing the stogit url if the specs are being downloaded for the first time.

Also removed logging import (not used anymore).
