### PR TITLE
Dockerfile: Remove unnecessary call to apt-get clean

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,9 +49,6 @@ RUN apt-get update
 # TODO Install any additional requirements.  Do we have any?
 RUN apt-get install -y gcc git g++ make
 
-# Clean up to reduce our overall image size.
-RUN apt-get clean
-
 # Print out the versions of the installed tools.
 RUN gcc --version \
     && g++ --version \


### PR DESCRIPTION
Since moving to a slim-based base image, this is no longer necessary.

In fact, this produces a 0B layer, as it does not change any files.

From `dive stodevx/cs251-toolkit:latest`:

![Dive](https://user-images.githubusercontent.com/1566689/48991518-cb68d180-f0f8-11e8-9c19-44e1bd45d2b2.png)

(Notice how Dive reports no removed files on the right when inspecting just the changes in the `apt-get clean` layer.)

Also, slim is configured to never allow those files to persist.