### PR TITLE
Improve ci flag

### DIFF
--- a/cs251tk/student/analyze.py
+++ b/cs251tk/student/analyze.py
@@ -37,7 +37,7 @@ def analyze_assignment(spec, assignment):
     folder = spec.get('folder', assignment)
     kind, num = parse_assignment_name(assignment)
     results = {'number': num, 'kind': kind}
-    
+
     if not os.path.exists(folder):
         results['status'] = 'missing'
         return results

--- a/cs251tk/student/analyze.py
+++ b/cs251tk/student/analyze.py
@@ -37,6 +37,7 @@ def analyze_assignment(spec, assignment):
     folder = spec.get('folder', assignment)
     kind, num = parse_assignment_name(assignment)
     results = {'number': num, 'kind': kind}
+    
     if not os.path.exists(folder):
         results['status'] = 'missing'
         return results

--- a/cs251tk/student/analyze.py
+++ b/cs251tk/student/analyze.py
@@ -7,12 +7,15 @@ from cs251tk.common import find_unmerged_branches_in_cwd
 from cs251tk.specs import get_filenames
 
 
-def analyze(student, specs, check_for_branches):
+def analyze(student, specs, check_for_branches, ci):
     logging.debug("Analyzing {}'s assignments".format(student))
-    unmerged_branches = has_unmerged_branches(student, check_for_branches)
+    unmerged_branches = None
+    if not ci:
+        unmerged_branches = has_unmerged_branches(student, check_for_branches)
 
     results = {}
-    with chdir(student):
+    directory = student if not ci else '.'
+    with chdir(directory):
         for spec in specs.values():
             assignment = spec['assignment']
             results[assignment] = analyze_assignment(spec, assignment)
@@ -34,7 +37,6 @@ def analyze_assignment(spec, assignment):
     folder = spec.get('folder', assignment)
     kind, num = parse_assignment_name(assignment)
     results = {'number': num, 'kind': kind}
-
     if not os.path.exists(folder):
         results['status'] = 'missing'
         return results

--- a/cs251tk/student/markdownify/markdownify.py
+++ b/cs251tk/student/markdownify/markdownify.py
@@ -10,9 +10,12 @@ from ...common import check_dates
 def markdownify(spec_id, *, username, spec, basedir, debug, interact, student, web, ci):
     """Run a spec against the current folder"""
     try:
-        first_submit = "First Submission for {}: {}".format(
-            spec_id,
-            check_dates(spec_id, username, spec, basedir)) if not ci else ''
+        first_submit = ''
+
+        if not ci:
+            first_submit = "First Submission for {}: {}".format(
+                spec_id,
+                check_dates(spec_id, username, spec, basedir))
 
         cwd = os.getcwd()
         results = {

--- a/cs251tk/student/markdownify/markdownify.py
+++ b/cs251tk/student/markdownify/markdownify.py
@@ -13,9 +13,10 @@ def markdownify(spec_id, *, username, spec, basedir, debug, interact, student, w
         first_submit = ''
 
         if not ci:
+            first_date = check_dates(spec_id, username, spec, basedir)
             first_submit = "First Submission for {}: {}".format(
                 spec_id,
-                check_dates(spec_id, username, spec, basedir))
+                first_date)
 
         cwd = os.getcwd()
         results = {

--- a/cs251tk/student/markdownify/markdownify.py
+++ b/cs251tk/student/markdownify/markdownify.py
@@ -14,9 +14,7 @@ def markdownify(spec_id, *, username, spec, basedir, debug, interact, student, w
 
         if not ci:
             first_date = check_dates(spec_id, username, spec, basedir)
-            first_submit = "First Submission for {}: {}".format(
-                spec_id,
-                first_date)
+            first_submit = "First Submission for {}: {}".format(spec_id, first_date)
 
         cwd = os.getcwd()
         results = {

--- a/cs251tk/student/markdownify/markdownify.py
+++ b/cs251tk/student/markdownify/markdownify.py
@@ -7,12 +7,12 @@ from .find_warnings import find_warnings
 from ...common import check_dates
 
 
-def markdownify(spec_id, *, username, spec, basedir, debug, interact, student, web):
+def markdownify(spec_id, *, username, spec, basedir, debug, interact, student, web, ci):
     """Run a spec against the current folder"""
     try:
         first_submit = "First Submission for {}: {}".format(
             spec_id,
-            check_dates(spec_id, username, spec, basedir))
+            check_dates(spec_id, username, spec, basedir)) if not ci else ''
 
         cwd = os.getcwd()
         results = {

--- a/cs251tk/student/record.py
+++ b/cs251tk/student/record.py
@@ -22,7 +22,8 @@ def record(student, *, specs, to_record, basedir, debug, interact, web, ci):
                                             debug=debug,
                                             interact=interact,
                                             student=student,
-                                            web=web)
+                                            web=web,
+                                            ci=ci)
             else:
                 recording = {
                     'spec': one_to_record,

--- a/cs251tk/student/record.py
+++ b/cs251tk/student/record.py
@@ -4,12 +4,13 @@ from cs251tk.common import chdir
 from cs251tk.student.markdownify import markdownify
 
 
-def record(student, *, specs, to_record, basedir, debug, interact, web):
+def record(student, *, specs, to_record, basedir, debug, interact, web, ci):
     recordings = []
     if not to_record:
         return recordings
 
-    with chdir(student):
+    directory = student if not ci else '.'
+    with chdir(directory):
         for one_to_record in to_record:
             logging.debug("Recording  {}'s {}".format(student, one_to_record))
             if path.exists(one_to_record):

--- a/cs251tk/toolkit/__main__.py
+++ b/cs251tk/toolkit/__main__.py
@@ -220,6 +220,7 @@ def main():
                                                   compilation['output'].replace("\n", "\n\t")))
                             failure = True
         if failure:
+            logging.debug('Build failed')
             sys.exit(1)
     else:
         save_recordings(records, debug=debug)

--- a/cs251tk/toolkit/__main__.py
+++ b/cs251tk/toolkit/__main__.py
@@ -150,8 +150,10 @@ def main():
 
     results = []
     records = []
-    makedirs('./students', exist_ok=True)
-    with chdir('./students'):
+    if not ci:
+        makedirs('./students', exist_ok=True)
+    directory = './students' if not ci else '.'
+    with chdir(directory):
         single = functools.partial(
             process_student,
             assignments=assignments,

--- a/cs251tk/toolkit/__main__.py
+++ b/cs251tk/toolkit/__main__.py
@@ -158,6 +158,7 @@ def main():
             process_student,
             assignments=assignments,
             basedir=basedir,
+            ci=ci,
             clean=clean,
             date=date,
             debug=debug,

--- a/cs251tk/toolkit/__main__.py
+++ b/cs251tk/toolkit/__main__.py
@@ -152,6 +152,7 @@ def main():
     records = []
     if not ci:
         makedirs('./students', exist_ok=True)
+
     directory = './students' if not ci else '.'
     with chdir(directory):
         single = functools.partial(

--- a/cs251tk/toolkit/args.py
+++ b/cs251tk/toolkit/args.py
@@ -2,6 +2,7 @@
 
 import datetime
 import argparse
+import os
 import sys
 import re
 import logging
@@ -164,14 +165,16 @@ def process_args():
     args = vars(parser.parse_args())
 
     if args['ci']:
-        if not args['course'] or not args['students']:
-            print("ci flag must be accompanied by course and student flags", file=sys.stderr)
+        if not args['course']:
+            print("ci flag must be accompanied by course flag", file=sys.stderr)
             sys.exit(1)
         args['highlight_partials'] = True
         args['no_progress'] = True
         args['no_update'] = True
         args['no_check'] = True
-        dirs = glob('students/*/hw*') + glob('students/*/lab*') + glob('students/*/ws*')
+        project_name = os.environ['CI_PROJECT_NAME']
+        args['students'] = [[project_name]]
+        dirs = glob('hw*') + glob('lab*') + glob('ws*')
         for line in dirs:
             args['to_record'].append([line.split('/')[-1]])
 

--- a/cs251tk/toolkit/args.py
+++ b/cs251tk/toolkit/args.py
@@ -165,15 +165,12 @@ def process_args():
     args = vars(parser.parse_args())
 
     if args['ci']:
-        if not args['course']:
-            print("ci flag must be accompanied by course flag", file=sys.stderr)
-            sys.exit(1)
         args['highlight_partials'] = True
         args['no_progress'] = True
         args['no_update'] = True
         args['no_check'] = True
-        project_name = os.environ['CI_PROJECT_NAME']
-        args['students'] = [[project_name]]
+        args['students'] = [[os.environ['CI_PROJECT_NAME']]]
+        args['course'] = [[os.environ['CI_PROJECT_NAMESPACE']]]
         dirs = glob('hw*') + glob('lab*') + glob('ws*')
         for line in dirs:
             args['to_record'].append([line.split('/')[-1]])

--- a/cs251tk/toolkit/args.py
+++ b/cs251tk/toolkit/args.py
@@ -170,7 +170,7 @@ def process_args():
         args['no_update'] = True
         args['no_check'] = True
         args['students'] = [[os.environ['CI_PROJECT_NAME']]]
-        args['course'] = [os.environ['CI_PROJECT_NAMESPACE']]
+        args['course'] = os.environ['CI_PROJECT_NAMESPACE']
         dirs = glob('hw*') + glob('lab*') + glob('ws*')
         for line in dirs:
             args['to_record'].append([line.split('/')[-1]])

--- a/cs251tk/toolkit/args.py
+++ b/cs251tk/toolkit/args.py
@@ -170,7 +170,7 @@ def process_args():
         args['no_update'] = True
         args['no_check'] = True
         args['students'] = [[os.environ['CI_PROJECT_NAME']]]
-        args['course'] = [[os.environ['CI_PROJECT_NAMESPACE']]]
+        args['course'] = [os.environ['CI_PROJECT_NAMESPACE']]
         dirs = glob('hw*') + glob('lab*') + glob('ws*')
         for line in dirs:
             args['to_record'].append([line.split('/')[-1]])

--- a/cs251tk/toolkit/process_student.py
+++ b/cs251tk/toolkit/process_student.py
@@ -39,7 +39,7 @@ def process_student(
         recordings = record(student, specs=specs, to_record=assignments, basedir=basedir, debug=debug,
                             interact=interact, web=web, ci=ci)
         analysis = analyze(student, specs, check_for_branches=not no_check, ci=ci)
-        print(analysis)
+
         if date:
             reset(student)
 

--- a/cs251tk/toolkit/process_student.py
+++ b/cs251tk/toolkit/process_student.py
@@ -13,6 +13,7 @@ def process_student(
         *,
         assignments,
         basedir,
+        ci,
         clean,
         date,
         debug,
@@ -25,19 +26,20 @@ def process_student(
 ):
     if clean:
         remove(student)
-
-    clone_student(student, baseurl=stogit_url)
+    if not ci:
+        clone_student(student, baseurl=stogit_url)
 
     try:
-        stash(student, no_update=no_update)
-        pull(student, no_update=no_update)
+        if not ci:
+            stash(student, no_update=no_update)
+            pull(student, no_update=no_update)
 
-        checkout_date(student, date=date)
+            checkout_date(student, date=date)
 
         recordings = record(student, specs=specs, to_record=assignments, basedir=basedir, debug=debug,
-                            interact=interact, web=web)
-        analysis = analyze(student, specs, check_for_branches=not no_check)
-
+                            interact=interact, web=web, ci=ci)
+        analysis = analyze(student, specs, check_for_branches=not no_check, ci=ci)
+        print(analysis)
         if date:
             reset(student)
 


### PR DESCRIPTION
- Removes the need to copy files to a `students/username` directory before running toolkit in gitlab-ci

With --ci:
- Determines the student and course automatically using the CI_PROJECT_NAME and CI_PROJECT_NAMESPACE environment variables
- Skips unnecessary operations that aren't relevant to ci

New .gitlab-ci.yml:
```
image: 'stodevx/cs251-toolkit:v2.#.#'
build:
  stage: build
  script:
    - cs251tk --ci
```