### PR TITLE
Improve web flag

### DIFF
--- a/cs251tk/student/markdownify/process_file.py
+++ b/cs251tk/student/markdownify/process_file.py
@@ -28,7 +28,7 @@ def get_file(filename, results, options):
     return True
 
 
-def compile_file(filename, steps, results, supporting_dir, basedir, web, student, spec_id):
+def compile_file(filename, *, steps, results, supporting_dir, basedir, web, web_file, student, spec_id):
     server_path = ' '.join([
         '-o "{}/server/server_file"'.format(basedir, spec_id),
         '"{}/data/supporting/{}/sd_fun.h"'.format(basedir, spec_id),
@@ -51,7 +51,7 @@ def compile_file(filename, steps, results, supporting_dir, basedir, web, student
             'status': status,
         })
 
-        if web:
+        if web and web_file:
             if status == 'success':
                 input("{} - {}".format(student, filename))
             else:
@@ -133,8 +133,15 @@ def process_file(filename, *, steps, options, spec, cwd, supporting_dir, interac
     if not should_continue or skip_web_compile and options['web']:
         return results
 
-    should_continue = compile_file(filename, steps, results, supporting_dir,
-                                   basedir, web, student, spec_id)
+    should_continue = compile_file(filename,
+                                   steps=steps,
+                                   results=results,
+                                   supporting_dir=supporting_dir,
+                                   basedir=basedir,
+                                   web=web,
+                                   web_file=options['web'],
+                                   student=student,
+                                   spec_id=spec_id)
 
     if not should_continue or not steps or options['web']:
         return results

--- a/cs251tk/toolkit/__main__.py
+++ b/cs251tk/toolkit/__main__.py
@@ -154,6 +154,8 @@ def main():
     if not ci:
         makedirs('./students', exist_ok=True)
 
+    makedirs('./server', exist_ok=True)
+
     directory = './students' if not ci else '.'
     with chdir(directory):
         single = functools.partial(

--- a/cs251tk/toolkit/__main__.py
+++ b/cs251tk/toolkit/__main__.py
@@ -154,7 +154,8 @@ def main():
     if not ci:
         makedirs('./students', exist_ok=True)
 
-    makedirs('./server', exist_ok=True)
+    if ci or web:
+        makedirs('./server', exist_ok=True)
 
     directory = './students' if not ci else '.'
     with chdir(directory):


### PR DESCRIPTION
- Fix an issue where all files were treated like web files (pausing after each file) if `--web` was used, regardless of if the file in the spec had `web: true`
- Create the server directory if it doesn't exist, preventing file not found errors when compiling web files
- Use keyword arguments for compile_file