### PR TITLE
Add new interactive cli for grading web files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,14 +40,14 @@ RUN ln -sv /cs251tk_share/students.txt /cs251tk/students.txt
 RUN ln -sv /cs251tk_share/.ssh/id_rsa /root/.ssh/id_rsa
 RUN ln -sv /cs251tk_share/.ssh/id_rsa.pub /root/.ssh/id_rsa.pub
 
-# Install the toolkit from the source directory.
-RUN pip3 install .
-
 # Update the package cache.
 RUN apt-get update
 
 # TODO Install any additional requirements.  Do we have any?
 RUN apt-get install -y gcc git g++ make
+
+# Install the toolkit from the source directory.
+RUN pip3 install .
 
 # Print out the versions of the installed tools.
 RUN gcc --version \

--- a/cs251tk/student/markdownify/markdownify.py
+++ b/cs251tk/student/markdownify/markdownify.py
@@ -7,7 +7,7 @@ from .find_warnings import find_warnings
 from ...common import check_dates
 
 
-def markdownify(spec_id, *, username, spec, basedir, debug, interact, student, web, ci, skip_web_compile):
+def markdownify(spec_id, *, username, spec, basedir, debug, interact, ci, skip_web_compile):
     """Run a spec against the current folder"""
     try:
         first_submit = ''
@@ -47,8 +47,6 @@ def markdownify(spec_id, *, username, spec, basedir, debug, interact, student, w
                                   supporting_dir=supporting,
                                   interact=interact,
                                   basedir=basedir,
-                                  student=student,
-                                  web=web,
                                   spec_id=spec_id,
                                   skip_web_compile=skip_web_compile)
             results['files'][filename] = result

--- a/cs251tk/student/markdownify/process_file.py
+++ b/cs251tk/student/markdownify/process_file.py
@@ -28,7 +28,7 @@ def get_file(filename, results, options):
     return True
 
 
-def compile_file(filename, *, steps, results, supporting_dir, basedir, web, web_file, student, spec_id):
+def compile_file(filename, *, steps, results, supporting_dir, basedir, spec_id):
     server_path = ' '.join([
         '-o "{}/server/server_file"'.format(basedir, spec_id),
         '"{}/data/supporting/{}/sd_fun.h"'.format(basedir, spec_id),
@@ -50,12 +50,6 @@ def compile_file(filename, *, steps, results, supporting_dir, basedir, web, web_
             'output': compilation,
             'status': status,
         })
-
-        if web and web_file:
-            if status == 'success':
-                input("{} - {}".format(student, filename))
-            else:
-                print("{} - {}  COMPILE ERROR".format(student, filename))
 
         if status != 'success':
             return False
@@ -107,7 +101,7 @@ def test_file(filename, *, spec, results, options, cwd, supporting_dir, interact
     return True
 
 
-def process_file(filename, *, steps, options, spec, cwd, supporting_dir, interact, basedir, student, web, spec_id,
+def process_file(filename, *, steps, options, spec, cwd, supporting_dir, interact, basedir, spec_id,
                  skip_web_compile):
     steps = steps if isinstance(steps, Iterable) else [steps]
 
@@ -138,9 +132,6 @@ def process_file(filename, *, steps, options, spec, cwd, supporting_dir, interac
                                    results=results,
                                    supporting_dir=supporting_dir,
                                    basedir=basedir,
-                                   web=web,
-                                   web_file=options['web'],
-                                   student=student,
                                    spec_id=spec_id)
 
     if not should_continue or not steps or options['web']:

--- a/cs251tk/student/record.py
+++ b/cs251tk/student/record.py
@@ -4,7 +4,7 @@ from cs251tk.common import chdir
 from cs251tk.student.markdownify import markdownify
 
 
-def record(student, *, specs, to_record, basedir, debug, interact, web, ci, skip_web_compile):
+def record(student, *, specs, to_record, basedir, debug, interact, ci, skip_web_compile):
     recordings = []
     if not to_record:
         return recordings
@@ -21,8 +21,6 @@ def record(student, *, specs, to_record, basedir, debug, interact, web, ci, skip
                                             basedir=basedir,
                                             debug=debug,
                                             interact=interact,
-                                            student=student,
-                                            web=web,
                                             ci=ci,
                                             skip_web_compile=skip_web_compile)
             else:

--- a/cs251tk/toolkit/__main__.py
+++ b/cs251tk/toolkit/__main__.py
@@ -184,7 +184,7 @@ def main():
             do_record = launch_cli(basedir=basedir,
                                    date=date,
                                    no_update=no_update,
-                                   spec=specs[next(iter(assignments))],
+                                   spec=specs[list(assignments)[0]],
                                    usernames=usernames)
             if do_record:
                 print_progress = make_progress_bar(usernames, no_progress=no_progress)

--- a/cs251tk/toolkit/__main__.py
+++ b/cs251tk/toolkit/__main__.py
@@ -179,25 +179,24 @@ def main():
 
         if web:
             Thread(target=run_server, args=(basedir,), daemon=True).start()
-            if usernames:
-                for user in usernames:
-                    clone_student(user, baseurl=stogit_url)
-                do_record = launch_cli(basedir=basedir,
-                                       date=date,
-                                       no_update=no_update,
-                                       spec=specs[next(iter(assignments))],
-                                       usernames=usernames)
-                if do_record:
-                    print_progress = make_progress_bar(usernames, no_progress=no_progress)
-                    with ProcessPoolExecutor(max_workers=workers) as pool:
-                        futures = [pool.submit(single, name) for name in usernames]
-                        for future in as_completed(futures):
-                            result, recording = future.result()
-                            print_progress(result['username'])
-                            results.append(result)
-                            records.extend(recording)
-                else:
-                    quiet = True
+            for user in usernames:
+                clone_student(user, baseurl=stogit_url)
+            do_record = launch_cli(basedir=basedir,
+                                   date=date,
+                                   no_update=no_update,
+                                   spec=specs[next(iter(assignments))],
+                                   usernames=usernames)
+            if do_record:
+                print_progress = make_progress_bar(usernames, no_progress=no_progress)
+                with ProcessPoolExecutor(max_workers=workers) as pool:
+                    futures = [pool.submit(single, name) for name in usernames]
+                    for future in as_completed(futures):
+                        result, recording = future.result()
+                        print_progress(result['username'])
+                        results.append(result)
+                        records.extend(recording)
+            else:
+                quiet = True
         elif workers > 1:
             print_progress = make_progress_bar(usernames, no_progress=no_progress)
             with ProcessPoolExecutor(max_workers=workers) as pool:

--- a/cs251tk/toolkit/__main__.py
+++ b/cs251tk/toolkit/__main__.py
@@ -7,6 +7,7 @@ from os import makedirs, getcwd
 import os.path
 import logging
 
+from ..student import clone_student
 from ..common import chdir, run
 from ..specs import load_all_specs, check_dependencies
 from .find_update import update_available
@@ -16,6 +17,7 @@ from .progress_bar import progress_bar
 from .save_recordings import save_recordings, gist_recordings
 from .tabulate import tabulate
 from ..webapp import server
+from ..webapp.web_cli import launch_cli
 
 
 def make_progress_bar(students, no_progress=False):
@@ -83,7 +85,7 @@ def main():
     web = args['web']
     workers = args['workers']
 
-    if debug or interact or web:
+    if debug or interact:
         workers = 1
 
     current_version, new_version = update_available(skip_update_check=skip_update_check)
@@ -172,11 +174,31 @@ def main():
             no_update=no_update,
             specs=specs,
             skip_web_compile=skip_web_compile,
-            stogit_url=stogit_url,
-            web=web
+            stogit_url=stogit_url
         )
 
-        if workers > 1:
+        if web:
+            Thread(target=run_server, args=(basedir,), daemon=True).start()
+            if usernames:
+                for user in usernames:
+                    clone_student(user, baseurl=stogit_url)
+                do_record = launch_cli(basedir=basedir,
+                                       date=date,
+                                       no_update=no_update,
+                                       spec=specs[next(iter(assignments))],
+                                       usernames=usernames)
+                if do_record:
+                    print_progress = make_progress_bar(usernames, no_progress=no_progress)
+                    with ProcessPoolExecutor(max_workers=workers) as pool:
+                        futures = [pool.submit(single, name) for name in usernames]
+                        for future in as_completed(futures):
+                            result, recording = future.result()
+                            print_progress(result['username'])
+                            results.append(result)
+                            records.extend(recording)
+                else:
+                    quiet = True
+        elif workers > 1:
             print_progress = make_progress_bar(usernames, no_progress=no_progress)
             with ProcessPoolExecutor(max_workers=workers) as pool:
                 futures = [pool.submit(single, name) for name in usernames]
@@ -185,13 +207,6 @@ def main():
                     print_progress(result['username'])
                     results.append(result)
                     records.extend(recording)
-        elif web:
-            Thread(target=run_server, args=(basedir,), daemon=True).start()
-            for student in usernames:
-                print("\nStudent: {}".format(student))
-                result, recording = single(student)
-                results.append(result)
-                records.extend(recording)
         else:
             for student in usernames:
                 logging.debug('Processing {}'.format(student))

--- a/cs251tk/toolkit/args.py
+++ b/cs251tk/toolkit/args.py
@@ -166,6 +166,10 @@ def process_args():
     parser = build_argparser()
     args = vars(parser.parse_args())
 
+    if args['web'] and not len(args['to_record']) == 1 or not len(args['to_record'][0]) == 1:
+        print('--web can only be used with one assignment at a time')
+        sys.exit(1)
+
     if args['ci']:
         args['highlight_partials'] = True
         args['no_progress'] = True

--- a/cs251tk/toolkit/args.py
+++ b/cs251tk/toolkit/args.py
@@ -126,9 +126,7 @@ def get_students_from_args(*, input_items, all_sections, sections, students, _al
             elif prefixed in _all_students:
                 student_set = _all_students[prefixed]
             else:
-                warning(('Neither section [section-{0}] nor [{0}] '
-                         'could not be found in ./students.txt'
-                         ).format(section_name))
+                warning('Neither section [section-{0}] nor [{0}] could not be found in ./students.txt'.format(section_name))
 
             collected.append(student_set)
         people = [student for group in collected for student in group]
@@ -167,10 +165,7 @@ def process_args():
 
     if args['web']:
         args['highlight_partials'] = True
-        if not len(args['to_record']) == 1:
-            print('--web can only be used with one assignment at a time')
-            sys.exit(1)
-        elif not len(args['to_record'][0]) == 1:
+        if not args['to_record'] or len(args['to_record']) != 1 or len(args['to_record'][0]) != 1:
             print('--web can only be used with one assignment at a time')
             sys.exit(1)
 

--- a/cs251tk/toolkit/args.py
+++ b/cs251tk/toolkit/args.py
@@ -170,6 +170,9 @@ def process_args():
         print('--web can only be used with one assignment at a time')
         sys.exit(1)
 
+    if args['web']:
+        args['highlight_partials'] = True
+
     if args['ci']:
         args['highlight_partials'] = True
         args['no_progress'] = True

--- a/cs251tk/toolkit/args.py
+++ b/cs251tk/toolkit/args.py
@@ -127,9 +127,9 @@ def get_students_from_args(*, input_items, all_sections, sections, students, _al
                 student_set = _all_students[prefixed]
             else:
                 warning((
-                    'Neither section [section-{0}] nor [{0}] '
-                    'could not be found in ./students.txt'
-                ).format(section_name))
+                            'Neither section [section-{0}] nor [{0}] '
+                            'could not be found in ./students.txt'
+                        ).format(section_name))
 
             collected.append(student_set)
         people = [student for group in collected for student in group]
@@ -166,13 +166,10 @@ def process_args():
     parser = build_argparser()
     args = vars(parser.parse_args())
 
-    try:
-        if args['web'] and not len(args['to_record']) == 1 or not len(args['to_record'][0]) == 1:
+    if args['web'] and not len(args['to_record']) == 1:
+        if not len(args['to_record'][0]) == 1:
             print('--web can only be used with one assignment at a time')
             sys.exit(1)
-    except IndexError:
-        print('--web can only be used with one assignment at a time')
-        sys.exit(1)
 
     if args['web']:
         args['highlight_partials'] = True

--- a/cs251tk/toolkit/args.py
+++ b/cs251tk/toolkit/args.py
@@ -165,13 +165,14 @@ def process_args():
     parser = build_argparser()
     args = vars(parser.parse_args())
 
-    if args['web'] and not len(args['to_record']) == 1:
-        if not len(args['to_record'][0]) == 1:
-            print('--web can only be used with one assignment at a time')
-            sys.exit(1)
-
     if args['web']:
         args['highlight_partials'] = True
+        if not len(args['to_record']) == 1:
+            print('--web can only be used with one assignment at a time')
+            sys.exit(1)
+        elif not len(args['to_record'][0]) == 1:
+            print('--web can only be used with one assignment at a time')
+            sys.exit(1)
 
     if args['ci']:
         args['highlight_partials'] = True

--- a/cs251tk/toolkit/args.py
+++ b/cs251tk/toolkit/args.py
@@ -166,7 +166,11 @@ def process_args():
     parser = build_argparser()
     args = vars(parser.parse_args())
 
-    if args['web'] and not len(args['to_record']) == 1 or not len(args['to_record'][0]) == 1:
+    try:
+        if args['web'] and not len(args['to_record']) == 1 or not len(args['to_record'][0]) == 1:
+            print('--web can only be used with one assignment at a time')
+            sys.exit(1)
+    except IndexError:
         print('--web can only be used with one assignment at a time')
         sys.exit(1)
 

--- a/cs251tk/toolkit/args.py
+++ b/cs251tk/toolkit/args.py
@@ -126,10 +126,9 @@ def get_students_from_args(*, input_items, all_sections, sections, students, _al
             elif prefixed in _all_students:
                 student_set = _all_students[prefixed]
             else:
-                warning((
-                            'Neither section [section-{0}] nor [{0}] '
-                            'could not be found in ./students.txt'
-                        ).format(section_name))
+                warning(('Neither section [section-{0}] nor [{0}] '
+                         'could not be found in ./students.txt'
+                         ).format(section_name))
 
             collected.append(student_set)
         people = [student for group in collected for student in group]

--- a/cs251tk/toolkit/process_student.py
+++ b/cs251tk/toolkit/process_student.py
@@ -22,8 +22,7 @@ def process_student(
         no_update,
         specs,
         skip_web_compile,
-        stogit_url,
-        web
+        stogit_url
 ):
     if clean:
         remove(student)
@@ -38,7 +37,7 @@ def process_student(
             checkout_date(student, date=date)
 
         recordings = record(student, specs=specs, to_record=assignments, basedir=basedir, debug=debug,
-                            interact=interact, web=web, ci=ci, skip_web_compile=skip_web_compile)
+                            interact=interact, ci=ci, skip_web_compile=skip_web_compile)
         analysis = analyze(student, specs, check_for_branches=not no_check, ci=ci)
 
         if date:

--- a/cs251tk/webapp/server.py
+++ b/cs251tk/webapp/server.py
@@ -24,7 +24,7 @@ class S(BaseHTTPRequestHandler):
         (stdout, stderr) = x.communicate(incoming_data)
         outgoing_data = stdout
         if len(stderr) > 0:
-            print(stderr, file=sys.stderr)
+            logging.debug(stderr, file=sys.stderr)
         self._set_headers()
         self.wfile.write(outgoing_data)
 

--- a/cs251tk/webapp/web_cli.py
+++ b/cs251tk/webapp/web_cli.py
@@ -28,8 +28,10 @@ def check_student(student, spec, basedir):
                         files = files + [file['filename'] + ' MISSING (OPTIONAL)']
                     else:
                         files = files + [file['filename'] + ' MISSING']
-                else:
+                elif 'web' in file['options']:
                     files = files + [file['filename']]
+                else:
+                    continue
     return files
 
 

--- a/cs251tk/webapp/web_cli.py
+++ b/cs251tk/webapp/web_cli.py
@@ -1,0 +1,128 @@
+import os
+
+from ..common import chdir
+from ..student import stash, pull, checkout_date
+from ..student.markdownify.process_file import process_file
+from PyInquirer import style_from_dict, Token, prompt
+
+
+def check_student(student, spec, basedir):
+    files = []
+    if os.path.exists('{}/{}'.format(student, spec['assignment'])):
+        with (chdir('{}/{}'.format(student, spec['assignment']))):
+            for file in spec['files']:
+
+                result = process_file(file['filename'],
+                                      steps=file['commands'],
+                                      options=file['options'],
+                                      spec=spec,
+                                      cwd=os.getcwd(),
+                                      supporting_dir=os.path.join(basedir, 'data', 'supporting'),
+                                      interact=False,
+                                      basedir=basedir,
+                                      spec_id=spec['assignment'],
+                                      skip_web_compile=False)
+
+                if result['missing']:
+                    if 'optional' in file['options']:
+                        files = files + [file['filename'] + ' MISSING (OPTIONAL)']
+                    else:
+                        files = files + [file['filename'] + ' MISSING']
+                else:
+                    files = files + [file['filename']]
+    return files
+
+
+def ask_student(usernames):
+    style = style_from_dict({
+        Token.QuestionMark: '#959ee7 bold',
+        Token.Selected: '#959ee7',
+        Token.Pointer: '#959ee7 bold',
+        Token.Answer: '#959ee7 bold',
+    })
+    questions = [
+        {
+            'type': 'list',
+            'name': 'student',
+            'message': 'Choose student',
+            'choices': ['QUIT', 'LOG and QUIT'] + usernames
+        }
+    ]
+
+    student = prompt(questions, style=style)
+
+    if not student:
+        return None
+
+    return student['student']
+
+
+def ask_file(files, student, spec, basedir):
+    style = style_from_dict({
+        Token.QuestionMark: '#e3bd27 bold',
+        Token.Selected: '#e3bd27',
+        Token.Pointer: '#e3bd27 bold',
+        Token.Answer: '#e3bd27 bold',
+    })
+
+    while True:
+        questions = [
+            {
+                'type': 'list',
+                'name': 'file',
+                'message': 'Choose file',
+                'choices': ['BACK'] + files,
+            }
+        ]
+        file = prompt(questions, style=style)
+
+        if not file or file['file'] == 'BACK':
+            return
+        else:
+            file_spec = {}
+            for f in spec['files']:
+                if f['filename'] == file['file']:
+                    file_spec = f
+                    break
+            if file_spec:
+                with (chdir('{}/{}'.format(student, spec['assignment']))):
+                    process_file(file_spec['filename'],
+                                 steps=file_spec['commands'],
+                                 options=file_spec['options'],
+                                 spec=spec,
+                                 cwd=os.getcwd(),
+                                 supporting_dir=os.path.join(basedir, 'data', 'supporting'),
+                                 interact=False,
+                                 basedir=basedir,
+                                 spec_id=spec['assignment'],
+                                 skip_web_compile=False)
+
+
+def launch_cli(basedir,
+               date,
+               no_update,
+               spec,
+               usernames):
+
+    while True:
+
+        student = ask_student(usernames)
+
+        if not student or student == 'QUIT':
+            return False
+        elif student == 'LOG and QUIT':
+            return True
+
+        stash(student, no_update=no_update)
+        pull(student, no_update=no_update)
+
+        checkout_date(student, date=date)
+
+        files = check_student(student, spec, basedir)
+
+        if files:
+            ask_file(files, student, spec, basedir)
+        else:
+            usernames = [
+                '{} NO SUBMISSION'.format(user) if user == student and 'NO SUBMISSION' not in user else user
+                for user in usernames]

--- a/cs251tk/webapp/web_cli.py
+++ b/cs251tk/webapp/web_cli.py
@@ -115,7 +115,6 @@ def launch_cli(basedir,
                  for user in usernames]
 
     while True:
-
         student = ask_student(usernames)
 
         if not student or student == 'QUIT':

--- a/cs251tk/webapp/web_cli.py
+++ b/cs251tk/webapp/web_cli.py
@@ -48,7 +48,7 @@ def ask_student(usernames):
             'type': 'list',
             'name': 'student',
             'message': 'Choose student',
-            'choices': ['QUIT', 'LOG and QUIT'] + usernames
+            'choices': ['QUIT', 'LOG and QUIT', *usernames]
         }
     ]
 
@@ -79,9 +79,7 @@ def ask_file(files, student, spec, basedir):
         ]
         file = prompt(questions, style=style)
 
-        if not file or file['file'] == 'BACK':
-            return
-        else:
+        if file and file['file'] != 'BACK':
             file_spec = {}
             for f in spec['files']:
                 if f['filename'] == file['file']:
@@ -101,18 +99,13 @@ def ask_file(files, student, spec, basedir):
                                  skip_web_compile=False)
 
 
-def launch_cli(basedir,
-               date,
-               no_update,
-               spec,
-               usernames):
+def launch_cli(basedir, date, no_update, spec, usernames):
     usernames = [
         '{} NO SUBMISSION'.format(user)
         if not os.path.exists('{}/{}'.format(user, spec['assignment']))
         else user
         for user in usernames
     ]
-                 for user in usernames]
 
     while True:
         student = ask_student(usernames)

--- a/cs251tk/webapp/web_cli.py
+++ b/cs251tk/webapp/web_cli.py
@@ -11,7 +11,6 @@ def check_student(student, spec, basedir):
     if os.path.exists('{}/{}'.format(student, spec['assignment'])):
         with chdir('{}/{}'.format(student, spec['assignment'])):
             for file in spec['files']:
-
                 result = process_file(file['filename'],
                                       steps=file['commands'],
                                       options=file['options'],

--- a/cs251tk/webapp/web_cli.py
+++ b/cs251tk/webapp/web_cli.py
@@ -99,6 +99,8 @@ def ask_file(files, student, spec, basedir):
                                  basedir=basedir,
                                  spec_id=spec['assignment'],
                                  skip_web_compile=False)
+        else:
+            return
 
 
 def launch_cli(basedir, date, no_update, spec, usernames):

--- a/cs251tk/webapp/web_cli.py
+++ b/cs251tk/webapp/web_cli.py
@@ -23,13 +23,14 @@ def check_student(student, spec, basedir):
                                       spec_id=spec['assignment'],
                                       skip_web_compile=False)
 
-                if result['missing']:
-                    if 'optional' in file['options']:
-                        files = files + [file['filename'] + ' MISSING (OPTIONAL)']
+                if 'web' in file['options']:
+                    if result['missing']:
+                        if 'optional' in file['options']:
+                            files = files + [file['filename'] + ' MISSING (OPTIONAL)']
+                        else:
+                            files = files + [file['filename'] + ' MISSING']
                     else:
-                        files = files + [file['filename'] + ' MISSING']
-                elif 'web' in file['options']:
-                    files = files + [file['filename']]
+                        files = files + [file['filename']]
                 else:
                     continue
     return files

--- a/cs251tk/webapp/web_cli.py
+++ b/cs251tk/webapp/web_cli.py
@@ -106,6 +106,8 @@ def launch_cli(basedir,
                no_update,
                spec,
                usernames):
+    usernames = ['{} NO SUBMISSION'.format(user) if not os.path.exists('{}/{}'.format(user, spec['assignment'])) else user
+                 for user in usernames]
 
     while True:
 
@@ -125,7 +127,3 @@ def launch_cli(basedir,
 
         if files:
             ask_file(files, student, spec, basedir)
-        else:
-            usernames = [
-                '{} NO SUBMISSION'.format(user) if user == student and 'NO SUBMISSION' not in user else user
-                for user in usernames]

--- a/cs251tk/webapp/web_cli.py
+++ b/cs251tk/webapp/web_cli.py
@@ -23,13 +23,15 @@ def check_student(student, spec, basedir):
                                       skip_web_compile=False)
 
                 if 'web' in file['options']:
+                    description = file['filename']
+
                     if result['missing']:
                         if 'optional' in file['options']:
-                            files = files + [file['filename'] + ' MISSING (OPTIONAL)']
+                            description = '{} MISSING (OPTIONAL)'.format(file['filename'])
                         else:
-                            files = files + [file['filename'] + ' MISSING']
-                    else:
-                        files = files + [file['filename']]
+                            description = '{} MISSING'.format(file['filename'])
+
+                    files = files + [description]
                 else:
                     continue
 

--- a/cs251tk/webapp/web_cli.py
+++ b/cs251tk/webapp/web_cli.py
@@ -9,7 +9,7 @@ from PyInquirer import style_from_dict, Token, prompt
 def check_student(student, spec, basedir):
     files = []
     if os.path.exists('{}/{}'.format(student, spec['assignment'])):
-        with (chdir('{}/{}'.format(student, spec['assignment']))):
+        with chdir('{}/{}'.format(student, spec['assignment'])):
             for file in spec['files']:
 
                 result = process_file(file['filename'],

--- a/cs251tk/webapp/web_cli.py
+++ b/cs251tk/webapp/web_cli.py
@@ -88,7 +88,7 @@ def ask_file(files, student, spec, basedir):
                     file_spec = f
                     break
             if file_spec:
-                with (chdir('{}/{}'.format(student, spec['assignment']))):
+                with chdir('{}/{}'.format(student, spec['assignment'])):
                     process_file(file_spec['filename'],
                                  steps=file_spec['commands'],
                                  options=file_spec['options'],

--- a/cs251tk/webapp/web_cli.py
+++ b/cs251tk/webapp/web_cli.py
@@ -32,6 +32,7 @@ def check_student(student, spec, basedir):
                         files = files + [file['filename']]
                 else:
                     continue
+
     return files
 
 

--- a/cs251tk/webapp/web_cli.py
+++ b/cs251tk/webapp/web_cli.py
@@ -106,7 +106,12 @@ def launch_cli(basedir,
                no_update,
                spec,
                usernames):
-    usernames = ['{} NO SUBMISSION'.format(user) if not os.path.exists('{}/{}'.format(user, spec['assignment'])) else user
+    usernames = [
+        '{} NO SUBMISSION'.format(user)
+        if not os.path.exists('{}/{}'.format(user, spec['assignment']))
+        else user
+        for user in usernames
+    ]
                  for user in usernames]
 
     while True:

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,8 @@ setup(
         'termcolor == 1.*',
         'natsort == 5.0.*',
         'appdirs == 1.4.*',
-        'python-dateutil == 2.7.*'
+        'python-dateutil == 2.7.*',
+        'PyInquirer == 1.0.*'
     ],
     tests_require=['tox'],
     packages=find_packages(exclude=['tests', 'docs']),

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         'natsort == 5.0.*',
         'appdirs == 1.4.*',
         'python-dateutil == 2.7.*',
-        'PyInquirer == 1.0.*'
+        'PyInquirer == 1.0.*',
     ],
     tests_require=['tox'],
     packages=find_packages(exclude=['tests', 'docs']),


### PR DESCRIPTION
Adds a new cli using PyInquirer that is used if the `--web` flag is included.

- Git repos are pulled first, then the cli is started.

## CLI
- The user chooses a student from the first menu.
- Another menu will appear with a list of the web files in the spec (files marked with `web: true`). If a student is missing a file,  `MISSING` is appended to the end of the file name.
- Choosing one of the files will compile the file so it is run by the server.
- The user can choose as many files as they want before selecting the `BACK` option, returning them to the first menu.
- The user can then:
  - choose another student
  - select `QUIT` to quit the application, or
  - select `LOG and QUIT` to create and print the table before quitting
- `NO SUBMISSION` will be appended to a student's id after it was selected if they have not submitted the homework and the user will be prompted to select another student.