### PR TITLE
Add support for .cs251tkignore files

### DIFF
--- a/cs251tk/toolkit/__main__.py
+++ b/cs251tk/toolkit/__main__.py
@@ -139,18 +139,30 @@ def main():
     if assignments:
         available_specs = set(assignments)
 
+        if ci:
+            ignored_specs = open('.cs251tkignore').read().split('\n')
+            logging.debug("Ignored specs: {}".format(ignored_specs))
+
+            for spec_to_use in assignments:
+                if spec_to_use in ignored_specs:
+                    available_specs.remove(spec_to_use)
+                    continue
+
         for spec_to_use in assignments:
             try:
                 check_dependencies(specs[spec_to_use])
             except KeyError:
-                print('Spec {} does not exist'.format(spec_to_use), file=sys.stderr)
+                if spec_to_use != 'lab0':
+                    print('Spec {} does not exist'.format(spec_to_use), file=sys.stderr)
                 available_specs.remove(spec_to_use)
 
         assignments = available_specs
 
         if not assignments:
-            print('no valid specs remaining', file=sys.stderr)
+            print('No valid specs remaining', file=sys.stderr)
             sys.exit(1)
+        else:
+            logging.debug("Remaining specs: {}".format(assignments))
 
     results = []
     records = []

--- a/cs251tk/toolkit/__main__.py
+++ b/cs251tk/toolkit/__main__.py
@@ -142,7 +142,7 @@ def main():
         if ci:
             with open('.cs251tkignore') as ignored_specs_file:
                 ignored_specs = ignored_specs_file.read().splitlines()
-                for i in range(0, len(ignored_specs)-1):
+                for i in range(0, len(ignored_specs) - 1):
                     ignored_specs[i] = ignored_specs[i].strip()
                 logging.debug("Ignored specs: {}".format(ignored_specs))
             available_specs = available_specs.difference(ignored_specs)

--- a/cs251tk/toolkit/__main__.py
+++ b/cs251tk/toolkit/__main__.py
@@ -140,10 +140,8 @@ def main():
         available_specs = set(assignments)
 
         if ci:
-            with open('.cs251tkignore') as ignored_specs_file:
-                ignored_specs = ignored_specs_file.read().splitlines()
-                for i in range(0, len(ignored_specs) - 1):
-                    ignored_specs[i] = ignored_specs[i].strip()
+            with open('.cs251tkignore') as infile:
+                ignored_specs = [line.strip() for line in infile.read().splitlines()]
                 logging.debug("Ignored specs: {}".format(ignored_specs))
             available_specs = available_specs.difference(ignored_specs)
 
@@ -151,6 +149,7 @@ def main():
             try:
                 check_dependencies(specs[spec_to_use])
             except KeyError:
+                # Prevent lab0 directory from causing an extraneous output
                 if spec_to_use != 'lab0':
                     print('Spec {} does not exist'.format(spec_to_use), file=sys.stderr)
                 available_specs.remove(spec_to_use)

--- a/cs251tk/toolkit/__main__.py
+++ b/cs251tk/toolkit/__main__.py
@@ -140,13 +140,12 @@ def main():
         available_specs = set(assignments)
 
         if ci:
-            ignored_specs = open('.cs251tkignore').read().split('\n')
-            logging.debug("Ignored specs: {}".format(ignored_specs))
-
-            for spec_to_use in assignments:
-                if spec_to_use in ignored_specs:
-                    available_specs.remove(spec_to_use)
-                    continue
+            with open('.cs251tkignore') as ignored_specs_file:
+                ignored_specs = ignored_specs_file.read().splitlines()
+                for i in range(0, len(ignored_specs)-1):
+                    ignored_specs[i] = ignored_specs[i].strip()
+                logging.debug("Ignored specs: {}".format(ignored_specs))
+            available_specs = available_specs.difference(ignored_specs)
 
         for spec_to_use in assignments:
             try:


### PR DESCRIPTION
Add support for a .cs251tkignore file to be added to the student's home directory that specifies which assignments should not be checked.
This is only applicable when the --ci flag is used.