### PR TITLE
Optional files don't cause assignment to be marked as partial

### DIFF
--- a/cs251tk/specs/util.py
+++ b/cs251tk/specs/util.py
@@ -4,15 +4,7 @@ from logging import warning
 
 def get_filenames(spec):
     """returns the list of files from an assignment spec"""
-    files = [file['filename'] for file in spec['files']]
-    for file in spec['files']:
-        try:
-            if file['options']['optional']:
-                files.remove(file['filename'])
-        except KeyError:
-            continue
-
-    return files
+    return [file['filename'] for file in spec['files'] if not file['options'].get('optional', False)]
 
 
 def check_dependencies(spec):

--- a/cs251tk/specs/util.py
+++ b/cs251tk/specs/util.py
@@ -4,7 +4,15 @@ from logging import warning
 
 def get_filenames(spec):
     """returns the list of files from an assignment spec"""
-    return [file['filename'] for file in spec['files']]
+    files = [file['filename'] for file in spec['files']]
+    for file in spec['files']:
+        try:
+            if file['options']['optional']:
+                files.remove(file['filename'])
+        except KeyError:
+            continue
+
+    return files
 
 
 def check_dependencies(spec):


### PR DESCRIPTION
Missing optional files were causing assignments to be marked as partially complete even if all required files were present. This removes optional files from the analysis.